### PR TITLE
simplify type signature

### DIFF
--- a/packages/@contentlayer/core/src/DataCache.ts
+++ b/packages/@contentlayer/core/src/DataCache.ts
@@ -36,7 +36,7 @@ export namespace DataCache {
   }: {
     schemaHash: string
     cwd: string
-  }): T.Effect<OT.HasTracer, fs.ReadFileError | fs.JsonParseError | GetContentlayerVersionError, Cache | undefined> =>
+  }): T.Effect<OT.HasTracer, GetContentlayerVersionError, Cache | undefined> =>
     T.gen(function* ($) {
       const cacheDirPath = yield* $(ArtifactsDir.getCacheDirPath({ cwd }))
       const filePath = path.join(cacheDirPath, dataCacheFileName(schemaHash))


### PR DESCRIPTION
Definitely not a huge addition but I noticed that [type GetContentlayerVersionError = fs.ReadFileError | fs.JsonParseError](https://github.com/contentlayerdev/contentlayer/blob/main/packages/%40contentlayer/utils/src/node/version.ts#L24)