### PR TITLE
fix rm type

### DIFF
--- a/packages/@contentlayer/utils/src/node/fs.ts
+++ b/packages/@contentlayer/utils/src/node/fs.ts
@@ -98,7 +98,7 @@ export const mkdirp = (dirPath: string): T.Effect<OT.HasTracer, MkdirError, void
 export function rm(path: string, params: { force: true; recursive?: boolean }): T.Effect<OT.HasTracer, RmError, void>
 export function rm(
   path: string,
-  params?: { force: false; recursive?: boolean },
+  params?: { force?: false; recursive?: boolean },
 ): T.Effect<OT.HasTracer, RmError | FileOrDirNotFoundError, void>
 
 export function rm(


### PR DESCRIPTION
This fixes a slight mistake I made in #19. Current types don't allow to define only the `recursive` option. i.e the following isn't allowed:

```ts
fs.rm(core.ArtifactsDir.getDirPath({ cwd: process.cwd() }), { recursive: true })
```