### PR TITLE
add meta data for npm packages

### DIFF
--- a/packages/contentlayer/package.json
+++ b/packages/contentlayer/package.json
@@ -68,5 +68,15 @@
   },
   "devDependencies": {
     "typescript": "^4.5.2"
+  },
+  "author": "schickling",
+  "homepage": "https://github.com/contentlayerdev/contentlayer",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/contentlayerdev/contentlayer.git"
+  },
+  "bug": {
+    "url": "https://github.com/contentlayerdev/contentlayer/issues"
   }
 }

--- a/packages/next-contentlayer/package.json
+++ b/packages/next-contentlayer/package.json
@@ -45,5 +45,15 @@
   "devDependencies": {
     "next": "^12.0.7",
     "typescript": "^4.5.2"
+  },
+  "author": "schickling",
+  "homepage": "https://github.com/contentlayerdev/contentlayer",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/contentlayerdev/contentlayer.git"
+  },
+  "bug": {
+    "url": "https://github.com/contentlayerdev/contentlayer/issues"
   }
 }


### PR DESCRIPTION
I found the package on https://www.npmjs.com/package/next-contentlayer. I want to see the source code of the project but it is not included in the npm page. This PR is to add those information for packages `contentlayer` and `next-contentlayer`. 
@schickling Please help to check if this PR is good and it needs to change anything (homepage, license...)
<img width="403" alt="Screenshot 2022-01-06 at 01 11 39" src="https://user-images.githubusercontent.com/8603085/148267605-7afa8240-ad45-4d97-aea9-304c756b1335.png">
