### PR TITLE
192 Expose RawDocumentData on vFile `data` field for Markdown/MDX Files

### DIFF
--- a/packages/@contentlayer/core/src/markdown.ts
+++ b/packages/@contentlayer/core/src/markdown.ts
@@ -5,6 +5,7 @@ import rehypeStringify from 'rehype-stringify'
 import remarkFrontmatter from 'remark-frontmatter'
 import remarkParse from 'remark-parse'
 import remark2rehype from 'remark-rehype'
+import type { Transformer } from 'unified'
 import { unified } from 'unified'
 
 import type { MarkdownOptions } from './plugin.js'
@@ -12,9 +13,11 @@ import type { MarkdownOptions } from './plugin.js'
 export const markdownToHtml = ({
   mdString,
   options,
+  data = {},
 }: {
   mdString: string
   options?: MarkdownOptions
+  data: any
 }): T.Effect<OT.HasTracer & HasConsole, UnexpectedMarkdownError, string> =>
   pipe(
     T.gen(function* ($) {
@@ -34,6 +37,12 @@ export const markdownToHtml = ({
       }
 
       const builder = unified()
+
+      const addRawDocumentMeta = (): Transformer => (_, vfile) => {
+        Object.assign(vfile.data, data)
+      }
+
+      builder.use(addRawDocumentMeta)
 
       // parses out the frontmatter (which is needed for full-document parsing)
       builder.use(remarkFrontmatter)

--- a/packages/@contentlayer/source-files/src/fetchData/mapping.ts
+++ b/packages/@contentlayer/source-files/src/fetchData/mapping.ts
@@ -273,6 +273,13 @@ const getDataForFieldDef = ({
         return value
       case 'markdown': {
         const isBodyField = fieldDef.name === options.fieldOptions.bodyFieldName
+        const data: RawDocumentData = {
+          sourceFilePath: relativeFilePath,
+          sourceFileName: path.basename(relativeFilePath),
+          sourceFileDir: path.dirname(relativeFilePath),
+          contentType: `markdown`,
+          flattenedPath: getFlattenedPath(relativeFilePath),
+        }
         // NOTE for the body field, we're passing the entire document file contents to MDX (e.g. in case some remark/rehype plugins need access to the frontmatter)
         // TODO we should come up with a better way to do this
         if (isBodyField) {
@@ -280,16 +287,23 @@ const getDataForFieldDef = ({
           if (rawContent.kind !== 'markdown' && rawContent.kind !== 'mdx') return utils.assertNever(rawContent)
 
           const html = yield* $(
-            core.markdownToHtml({ mdString: rawContent.rawDocumentContent, options: options?.markdown }),
+            core.markdownToHtml({ mdString: rawContent.rawDocumentContent, options: options?.markdown, data }),
           )
           return identity<core.Markdown>({ raw: rawFieldData, html })
         } else {
-          const html = yield* $(core.markdownToHtml({ mdString: rawFieldData, options: options?.markdown }))
+          const html = yield* $(core.markdownToHtml({ mdString: rawFieldData, options: options?.markdown, data }))
           return identity<core.Markdown>({ raw: rawFieldData, html })
         }
       }
       case 'mdx': {
         const isBodyField = fieldDef.name === options.fieldOptions.bodyFieldName
+        const data: RawDocumentData = {
+          sourceFilePath: relativeFilePath,
+          sourceFileName: path.basename(relativeFilePath),
+          sourceFileDir: path.dirname(relativeFilePath),
+          contentType: `mdx`,
+          flattenedPath: getFlattenedPath(relativeFilePath),
+        }
         // NOTE for the body field, we're passing the entire document file contents to MDX (e.g. in case some remark/rehype plugins need access to the frontmatter)
         // TODO we should come up with a better way to do this
         if (isBodyField) {
@@ -297,11 +311,13 @@ const getDataForFieldDef = ({
           if (rawContent.kind !== 'mdx' && rawContent.kind !== 'markdown') return utils.assertNever(rawContent)
 
           const code = yield* $(
-            core.bundleMDX({ mdxString: rawContent.rawDocumentContent, options: options?.mdx, contentDirPath }),
+            core.bundleMDX({ mdxString: rawContent.rawDocumentContent, options: options?.mdx, contentDirPath, data }),
           )
           return identity<core.MDX>({ raw: rawFieldData, code })
         } else {
-          const code = yield* $(core.bundleMDX({ mdxString: rawFieldData, options: options?.mdx, contentDirPath }))
+          const code = yield* $(
+            core.bundleMDX({ mdxString: rawFieldData, options: options?.mdx, contentDirPath, data }),
+          )
           return identity<core.MDX>({ raw: rawFieldData, code })
         }
       }


### PR DESCRIPTION
Implementation for the request in #192 that also partially solves for #11.

In `@contentlayer/core` I added a new `data` field to the  options argument of `markdownToHtml` and `bundleMDX` which can be used to pass arbitrary data to the resulting document's `vFile` `data` property.

Not knowing how you want to structure utility functions for this library, in the initial implementation I've inlined the `addRawDocumentMeta` remark plugin used to append the vFile inside of both `markdownToHtml` and `bundleMDX`. Please advise me if you'd like this extracted out to somewhere else instead.

In this PR I've only updated the `mapping.ts` file for the `source-files` package, as I'm unsure whether other sources like `source-contentful` expose the same `RawDocumentData` that the filesystem source does. Other sources can pass whatever document metadata is pertinent to them to the markdown processors using this addition to their APIs.