### PR TITLE
Add remarkRehypeOptions and rehypeStringifyOptions to provide options to default Markdown processors

### DIFF
--- a/.changeset/fluffy-tomatoes-lay.md
+++ b/.changeset/fluffy-tomatoes-lay.md
@@ -1,0 +1,5 @@
+---
+'@contentlayer/core': patch
+---
+
+Add remarkRehypeOptions and rehypeStringifyOptions

--- a/packages/@contentlayer/core/src/markdown.ts
+++ b/packages/@contentlayer/core/src/markdown.ts
@@ -45,14 +45,14 @@ export const markdownToHtml = ({
         builder.use(options.remarkPlugins)
       }
 
-      builder.use(remark2rehype)
+      builder.use(remark2rehype, options?.remarkRehypeOptions)
 
       if (options?.rehypePlugins) {
         builder.use(options.rehypePlugins)
       }
 
       // rehype to html
-      builder.use(rehypeStringify as any)
+      builder.use(rehypeStringify as any, options?.rehypeStringifyOptions)
 
       const res = yield* $(T.tryPromise(() => builder.process(mdString)))
 

--- a/packages/@contentlayer/core/src/plugin.ts
+++ b/packages/@contentlayer/core/src/plugin.ts
@@ -1,6 +1,8 @@
 import type { Thunk } from '@contentlayer/utils'
 import type { E, HasClock, HasConsole, OT, S, T } from '@contentlayer/utils/effect'
 import type { BundleMDXOptions } from 'mdx-bundler/dist/types'
+import type { Options as RehypeStringifyOptions } from 'rehype-stringify'
+import type { Options as RemarkRehypeOptions } from 'remark-rehype'
 import type { LiteralUnion } from 'type-fest'
 import type * as unified from 'unified'
 
@@ -25,6 +27,8 @@ export type PluginOptions = {
 }
 
 export type MarkdownOptions = {
+  remarkRehypeOptions?: RemarkRehypeOptions,
+  rehypeStringifyOptions?: RehypeStringifyOptions,
   remarkPlugins?: unified.Pluggable[]
   rehypePlugins?: unified.Pluggable[]
 }


### PR DESCRIPTION
#202 

This is the minimum amount of work to allow custom options to be passed to the default processors to allow raw HTML tags among other things

Let me know if automated tests are required (I don't see any for the existing code in `markdown.ts`..)

Here are some screenshots that were taken during testing (using examples/next-contentlayer-example):

<figure>
<img width="2042" alt="Screenshot 2022-04-30 at 3 17 03 PM" src="https://user-images.githubusercontent.com/2081441/166096067-57a6cfbc-751b-4f5d-806b-f657ea393612.png">
<figcaption>When the options are excluded, there are no errors</figcaption>
</figure>

<br/>
<br/>
<br/>

With the following options in `examples/next-contentlayer-example/contentlayer.config.ts`
```
  markdown: {
    remarkRehypeOptions: { allowDangerousHtml: true },
    rehypeStringifyOptions: { allowDangerousHtml: true }
  }
 ```

<figure>
<img width="1949" alt="Screenshot 2022-04-30 at 3 16 31 PM" src="https://user-images.githubusercontent.com/2081441/166096073-b7397ec3-12b7-40e3-b9af-59589434461b.png">
<figcaption>When including the options, it is passed down correctly and renders raw HTML as expected</figcaption>
</figure>
