### PR TITLE
docs: fix typo

### DIFF
--- a/packages/@contentlayer/source-files/src/schema/defs/index.ts
+++ b/packages/@contentlayer/source-files/src/schema/defs/index.ts
@@ -23,7 +23,7 @@ export type DocumentTypeDef<DefName extends string = string> = {
   description?: string
 
   /**
-   * The field definitions can either be provided as an embedded with the field names as keys or
+   * The field definitions can either be provided as an object with the field names as keys or
    * as an array of all field definitions including the name as an extra field. (The array definition
    * can be used if you want more control over the order of the fields.)
    */
@@ -37,7 +37,7 @@ export type DocumentTypeDef<DefName extends string = string> = {
   /**
    * Default is `markdown`
    *
-   * Choose `none` e.g. for a `.json` or `.yaml` file
+   * Choose `data` e.g. for a `.json` or `.yaml` file
    */
   contentType?: DocumentContentType
 


### PR DESCRIPTION
this fixes a small typo in a doc comment: `DocumentContentType` should be `data` for `.json` etc. files, not `none`, see https://github.com/stefanprobst/contentlayer/blob/a6292d281d01194c36051db6a0dcfa97146790e1/packages/%40contentlayer/source-files/src/schema/defs/index.ts#L13