### PR TITLE
feat: allow passing config path via next-contentlayer

### DIFF
--- a/packages/next-contentlayer/src/index-cjs.ts
+++ b/packages/next-contentlayer/src/index-cjs.ts
@@ -1,12 +1,12 @@
 import type { NextConfig } from 'next'
 
-export type { NextConfig }
+import type { NextPluginOptions } from './plugin.js'
 
-export type PluginOptions = {}
+export type { NextConfig }
 
 let devServerStarted = false
 
-const defaultPluginOptions: PluginOptions = {}
+const defaultPluginOptions: NextPluginOptions = {}
 module.exports.defaultPluginOptions = defaultPluginOptions
 
 /**
@@ -25,7 +25,7 @@ module.exports.defaultPluginOptions = defaultPluginOptions
  * ```
  */
 module.exports.createContentlayerPlugin =
-  (_pluginOptions: PluginOptions = {}) =>
+  (pluginOptions: NextPluginOptions = defaultPluginOptions) =>
   (nextConfig: Partial<NextConfig> = {}): Partial<NextConfig> => {
     // could be either `next dev` or just `next`
     const isNextDev = process.argv.includes('dev') || process.argv.some((_) => _.endsWith('/.bin/next'))
@@ -43,11 +43,11 @@ module.exports.createContentlayerPlugin =
         // NOTE since next.config.js doesn't support ESM yet, this "CJS -> ESM bridge" is needed
         const { runContentlayerBuild, runContentlayerDev } = await import('./plugin.js')
         if (isBuild) {
-          await runContentlayerBuild()
+          await runContentlayerBuild(pluginOptions)
         } else if (isNextDev && !devServerStarted) {
           devServerStarted = true
           // TODO also block here until first Contentlayer run is complete
-          runContentlayerDev()
+          runContentlayerDev(pluginOptions)
         }
 
         return nextConfig.redirects?.() ?? []

--- a/packages/next-contentlayer/src/index.ts
+++ b/packages/next-contentlayer/src/index.ts
@@ -1,17 +1,13 @@
 import type { NextConfig } from 'next'
 
 import { checkConstraints } from './check-constraints.js'
-import { runContentlayerBuild, runContentlayerDev } from './plugin.js'
+import { type NextPluginOptions, runContentlayerBuild, runContentlayerDev } from './plugin.js'
 
 export type { NextConfig }
 
-export type PluginOptions = {
-  configPath?: string | undefined
-}
-
 let devServerStarted = false
 
-export const defaultPluginOptions: PluginOptions = {}
+export const defaultPluginOptions: NextPluginOptions = {}
 
 /**
  * This function allows you to provide custom plugin options (currently there are none however).
@@ -29,59 +25,59 @@ export const defaultPluginOptions: PluginOptions = {}
  * ```
  */
 export const createContentlayerPlugin =
-  (pluginOptions: PluginOptions = {}) =>
-    (nextConfig: Partial<NextConfig> = {}): Partial<NextConfig> => {
-      // could be either `next dev` or just `next`
-      const isNextDev = process.argv.includes('dev') || process.argv.some((_) => _.endsWith('/.bin/next'))
-      const isBuild = process.argv.includes('build')
+  (pluginOptions: NextPluginOptions = defaultPluginOptions) =>
+  (nextConfig: Partial<NextConfig> = {}): Partial<NextConfig> => {
+    // could be either `next dev` or just `next`
+    const isNextDev = process.argv.includes('dev') || process.argv.some((_) => _.endsWith('/.bin/next'))
+    const isBuild = process.argv.includes('build')
 
-      const { configPath } = pluginOptions
+    const { configPath } = pluginOptions
 
-      return {
-        ...nextConfig,
-        // Since Next.js doesn't provide some kind of real "plugin system" we're (ab)using the `redirects` option here
-        // in order to hook into and block the `next build` and initial `next dev` run.
-        redirects: async () => {
-          if (isBuild) {
-            checkConstraints()
-            await runContentlayerBuild({ configPath })
-          } else if (isNextDev && !devServerStarted) {
-            devServerStarted = true
-            // TODO also block here until first Contentlayer run is complete
-            runContentlayerDev({ configPath })
-          }
+    return {
+      ...nextConfig,
+      // Since Next.js doesn't provide some kind of real "plugin system" we're (ab)using the `redirects` option here
+      // in order to hook into and block the `next build` and initial `next dev` run.
+      redirects: async () => {
+        if (isBuild) {
+          checkConstraints()
+          await runContentlayerBuild({ configPath })
+        } else if (isNextDev && !devServerStarted) {
+          devServerStarted = true
+          // TODO also block here until first Contentlayer run is complete
+          runContentlayerDev({ configPath })
+        }
 
-          return nextConfig.redirects?.() ?? []
-        },
-        onDemandEntries: {
-          maxInactiveAge: 60 * 60 * 1000, // extend `maxInactiveAge` to 1 hour (from 15 sec by default)
-          ...nextConfig.onDemandEntries, // use existing onDemandEntries config if provided by user
-        },
-        webpack(config: any, options: any) {
-          config.watchOptions = {
-            ...config.watchOptions,
-            // ignored: /node_modules([\\]+|\/)+(?!\.contentlayer)/,
-            ignored: ['**/node_modules/!(.contentlayer)/**/*'],
-          }
+        return nextConfig.redirects?.() ?? []
+      },
+      onDemandEntries: {
+        maxInactiveAge: 60 * 60 * 1000, // extend `maxInactiveAge` to 1 hour (from 15 sec by default)
+        ...nextConfig.onDemandEntries, // use existing onDemandEntries config if provided by user
+      },
+      webpack(config: any, options: any) {
+        config.watchOptions = {
+          ...config.watchOptions,
+          // ignored: /node_modules([\\]+|\/)+(?!\.contentlayer)/,
+          ignored: ['**/node_modules/!(.contentlayer)/**/*'],
+        }
 
-          // NOTE workaround for https://github.com/vercel/next.js/issues/17806#issuecomment-913437792
-          // https://github.com/contentlayerdev/contentlayer/issues/121
-          config.module.rules.push({
-            test: /\.m?js$/,
-            type: 'javascript/auto',
-            resolve: {
-              fullySpecified: false,
-            },
-          })
+        // NOTE workaround for https://github.com/vercel/next.js/issues/17806#issuecomment-913437792
+        // https://github.com/contentlayerdev/contentlayer/issues/121
+        config.module.rules.push({
+          test: /\.m?js$/,
+          type: 'javascript/auto',
+          resolve: {
+            fullySpecified: false,
+          },
+        })
 
-          if (typeof nextConfig.webpack === 'function') {
-            return nextConfig.webpack(config, options)
-          }
+        if (typeof nextConfig.webpack === 'function') {
+          return nextConfig.webpack(config, options)
+        }
 
-          return config
-        },
-      }
+        return config
+      },
     }
+  }
 
 /**
  * Next.js plugin for Contentlayer with default options.

--- a/packages/next-contentlayer/src/plugin.ts
+++ b/packages/next-contentlayer/src/plugin.ts
@@ -4,14 +4,14 @@ import * as core from '@contentlayer/core'
 import { errorToString } from '@contentlayer/utils'
 import { E, OT, pipe, S, T } from '@contentlayer/utils/effect'
 
-type Options = {
+export type NextPluginOptions = {
   configPath?: string | undefined
 }
 
 /** Seems like the next.config.js export function might be executed multiple times, so we need to make sure we only run it once */
 let contentlayerInitialized = false
 
-export const runContentlayerDev = async ({ configPath }: Options) => {
+export const runContentlayerDev = async ({ configPath }: NextPluginOptions) => {
   if (contentlayerInitialized) return
   contentlayerInitialized = true
 
@@ -26,7 +26,7 @@ export const runContentlayerDev = async ({ configPath }: Options) => {
   )
 }
 
-export const runContentlayerBuild = async ({ configPath }: Options) => {
+export const runContentlayerBuild = async ({ configPath }: NextPluginOptions) => {
   if (contentlayerInitialized) return
   contentlayerInitialized = true
 


### PR DESCRIPTION
allows passing a custom `configPath` via the Next.js plugin, similar to the `--config` CLI flag.

closes #234