### PR TITLE
Remove leerob.io and ped.ro source link from README

### DIFF
--- a/packages/contentlayer/README.md
+++ b/packages/contentlayer/README.md
@@ -51,7 +51,6 @@ Join [our Discord community](https://discord.gg/fk83HNECYJ) to get help, suggest
 
 - [ped.ro](https://ped.ro) ([Source](https://github.com/peduarte/ped.ro))
 - [GraphCMS Docs](https://graphcms.com/docs)
-- [leerob.io](https://leerob.io/) ([Source](https://github.com/leerob/leerob.io))
 - [axeldelafosse.com](https://axeldelafosse.com) ([Source](https://github.com/axeldelafosse/axeldelafosse))
 - [arthurvdiniz.me](https://arthurvdiniz.me) ([Source](https://github.com/arthurvdiniz/me))
 - [imadatyatalah.vercel.app](https://imadatyatalah.vercel.app) ([Source](https://github.com/imadatyatalah/imadatyatalah.me))

--- a/packages/contentlayer/README.md
+++ b/packages/contentlayer/README.md
@@ -49,7 +49,7 @@ Join [our Discord community](https://discord.gg/fk83HNECYJ) to get help, suggest
 
 ### Who is using Contentlayer?
 
-- [ped.ro](https://ped.ro) ([Source](https://github.com/peduarte/ped.ro))
+- [ped.ro](https://ped.ro)
 - [GraphCMS Docs](https://graphcms.com/docs)
 - [axeldelafosse.com](https://axeldelafosse.com) ([Source](https://github.com/axeldelafosse/axeldelafosse))
 - [arthurvdiniz.me](https://arthurvdiniz.me) ([Source](https://github.com/arthurvdiniz/me))


### PR DESCRIPTION
### leerob.io
- Lee removed Contentlayer from his website 😢 He migrated to Sanity. [Check commit here](https://github.com/leerob/leerob.io/commit/b34f4cac2319be77c05f57ca444e8d16cdc44a37#diff-82564f14f478f0fb2cfdd630090a4d534c6dc2faf5f3de7e10524434d4cbed45)

### ped.ro
- Pedro made his repo private