### PR TITLE
chore: adding hellonext to readme

### DIFF
--- a/packages/contentlayer/README.md
+++ b/packages/contentlayer/README.md
@@ -91,5 +91,6 @@ Join [our Discord community](https://discord.gg/fk83HNECYJ) to get help, suggest
 - [igorkowalczyk.dev](https://igorkowalczyk.dev) ([Source](https://github.com/igorkowalczyk/igorkowalczyk.github.io))
 - [christianpenrod.com](https://christianpenrod.com) ([Source](https://github.com/penrodlol/christianpenrod))
 - [xahidex.com](https://xahidex.com)
+- [hellonext.co](https://hellonext.co)
 
 Are you using Contentlayer? Please add your page (and repo) to the end of the list via a PR. 🙏


### PR DESCRIPTION
Adding Hellonext (using Contentlayer in production) to Readme.