### PR TITLE
improve mdxOptions handling

### DIFF
--- a/packages/@contentlayer/core/src/markdown/mdx.ts
+++ b/packages/@contentlayer/core/src/markdown/mdx.ts
@@ -26,7 +26,14 @@ export const bundleMDX = ({
       if (mdxString.length === 0) {
         return ''
       }
-      const { rehypePlugins, remarkPlugins, resolveCwd, cwd: cwd_, mdxOptions: mdxOptions_, ...restOptions } = options ?? {}
+      const {
+        rehypePlugins,
+        remarkPlugins,
+        resolveCwd,
+        cwd: cwd_,
+        mdxOptions: mapMdxOptions,
+        ...restOptions
+      } = options ?? {}
 
       const getCwdFromContentDirPath = () =>
         // TODO don't use `process.cwd()` but instead `HasCwd`
@@ -44,7 +51,7 @@ export const bundleMDX = ({
             ...(opts.remarkPlugins ?? []),
             ...(remarkPlugins ?? []),
           ]
-          return mdxOptions_ ? mdxOptions_(opts) : opts;
+          return mapMdxOptions ? mapMdxOptions(opts) : opts
         },
         // User-provided cwd trumps resolution
         cwd: cwd_ ?? getCwd(),

--- a/packages/@contentlayer/core/src/markdown/mdx.ts
+++ b/packages/@contentlayer/core/src/markdown/mdx.ts
@@ -26,7 +26,7 @@ export const bundleMDX = ({
       if (mdxString.length === 0) {
         return ''
       }
-      const { rehypePlugins, remarkPlugins, resolveCwd, cwd: cwd_, ...restOptions } = options ?? {}
+      const { rehypePlugins, remarkPlugins, resolveCwd, cwd: cwd_, mdxOptions: mdxOptions_, ...restOptions } = options ?? {}
 
       const getCwdFromContentDirPath = () =>
         // TODO don't use `process.cwd()` but instead `HasCwd`
@@ -44,7 +44,7 @@ export const bundleMDX = ({
             ...(opts.remarkPlugins ?? []),
             ...(remarkPlugins ?? []),
           ]
-          return opts
+          return mdxOptions_ ? mdxOptions_(opts) : opts;
         },
         // User-provided cwd trumps resolution
         cwd: cwd_ ?? getCwd(),

--- a/packages/@contentlayer/core/src/plugin.ts
+++ b/packages/@contentlayer/core/src/plugin.ts
@@ -60,8 +60,6 @@ export type MDXOptions = {
   /**
    * This allows you to modify the built-in MDX configuration (passed to @mdx-js/mdx compile).
    * This can be helpful for specifying your own remarkPlugins/rehypePlugins.
-   *
-   * If you're providing `mdxOptions` then `rehypePlugins` and `remarkPlugins` will be ignored.
    */
   mdxOptions?: MDXBundlerMDXOptions
   /**

--- a/packages/@contentlayer/core/src/plugin.ts
+++ b/packages/@contentlayer/core/src/plugin.ts
@@ -1,5 +1,6 @@
 import type { Thunk } from '@contentlayer/utils'
 import type { E, HasClock, HasConsole, OT, S, T } from '@contentlayer/utils/effect'
+import type * as mdxEsbuild from '@mdx-js/esbuild/lib'
 import type * as mdxBundler from 'mdx-bundler/dist/types'
 import type { LiteralUnion } from 'type-fest'
 import type * as unified from 'unified'
@@ -58,10 +59,13 @@ export type MDXOptions = {
   rehypePlugins?: unified.Pluggable[]
   /**  */
   /**
-   * This allows you to modify the built-in MDX configuration (passed to @mdx-js/mdx compile).
+   * This allows you to modify the built-in MDX configuration (passed to @mdx-js/mdx compile via mdx-bundler).
    * This can be helpful for specifying your own remarkPlugins/rehypePlugins.
+   *
+   * Note that Contentlayer by default applies the built-in `addRawDocumentToVFile` remark plugin
+   * which adds the raw document data to the vfile under `vfile.data.rawDocumentData`.
    */
-  mdxOptions?: MDXBundlerMDXOptions
+  mdxOptions?: MDXBundlerMapOptions
   /**
    * How we resolve the cwd passed to mdx-bundler when processing a file. If an explicit `cwd`
    * is provided this option will be ignored.
@@ -72,7 +76,7 @@ export type MDXOptions = {
   resolveCwd?: 'relative' | 'contentDirPath'
 } & Omit<mdxBundler.BundleMDXOptions<any>, 'mdxOptions'>
 
-export type MDXBundlerMDXOptions = mdxBundler.BundleMDXOptions<any>['mdxOptions']
+export type MDXBundlerMapOptions = (options: mdxEsbuild.ProcessorOptions) => mdxEsbuild.ProcessorOptions
 
 export type DateOptions = {
   /**


### PR DESCRIPTION
Currently, if you modify `mdxOptions` then you will have no way of accessing `rawDocumentData` in your plugins. With this change you will still be able to do that since the changes from contentlayer will be forwarded to the user function. The collateral effect of this change is also that `remarkPlugins` and `rehypePlugins` will not be lost when `mdxOptions` is overridden.