### PR TITLE
fix: #337 add file name transfrom

### DIFF
--- a/packages/@contentlayer/core/package.json
+++ b/packages/@contentlayer/core/package.json
@@ -37,7 +37,8 @@
     "remark-rehype": "^10.1.0",
     "source-map-support": "^0.5.21",
     "type-fest": "^3.2.0",
-    "unified": "^10.1.2"
+    "unified": "^10.1.2",
+    "transliteration": "^2.3.5"
   },
   "devDependencies": {
     "@types/source-map-support": "^0.5.6",

--- a/packages/@contentlayer/core/src/generation/generate-dotpkg.ts
+++ b/packages/@contentlayer/core/src/generation/generate-dotpkg.ts
@@ -6,6 +6,7 @@ import { Array, Chunk, flow, OT, pipe, S, T } from '@contentlayer/utils/effect'
 import { fs } from '@contentlayer/utils/node'
 import { camelCase } from 'camel-case'
 import type { PackageJson } from 'type-fest'
+import { slugify } from 'transliteration'
 
 import { ArtifactsDir } from '../ArtifactsDir.js'
 import type { HasCwd } from '../cwd.js'
@@ -392,7 +393,7 @@ const leftPadWithUnderscoreIfStartsWithNumber = (str: string): string => {
   if (/^[0-9]/.test(str)) {
     return '_' + str
   }
-  return str
+  return slugify(str,{ separator: "_" })
 }
 
 // const errorIfArtifactsDirIsDeleted = ({ artifactsDir }: { artifactsDir: string }) => {


### PR DESCRIPTION
fix: https://github.com/contentlayerdev/contentlayer/issues/337

Use `transliteration` for filenames in other languages.