### PR TITLE
fix: #335 upgrade mdx-bundler version 9.0.1 to 9.2.1

### DIFF
--- a/packages/@contentlayer/core/package.json
+++ b/packages/@contentlayer/core/package.json
@@ -30,7 +30,7 @@
     "comment-json": "^4.2.3",
     "esbuild": "^0.12.1 || 0.13.x || 0.14.x || 0.15.x",
     "gray-matter": "^4.0.3",
-    "mdx-bundler": "^9.0.1",
+    "mdx-bundler": "^9.2.1",
     "rehype-stringify": "^9.0.3",
     "remark-frontmatter": "^4.0.1",
     "remark-parse": "^10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -310,7 +310,7 @@ __metadata:
     esbuild: ^0.12.1 || 0.13.x || 0.14.x || 0.15.x
     gray-matter: ^4.0.3
     markdown-wasm: ^1.2.0
-    mdx-bundler: ^9.0.1
+    mdx-bundler: ^9.2.1
     rehype-stringify: ^9.0.3
     remark-frontmatter: ^4.0.1
     remark-parse: ^10.0.1
@@ -5642,9 +5642,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mdx-bundler@npm:^9.0.1":
-  version: 9.0.1
-  resolution: "mdx-bundler@npm:9.0.1"
+"mdx-bundler@npm:^9.2.1":
+  version: 9.2.1
+  resolution: "mdx-bundler@npm:9.2.1"
   dependencies:
     "@babel/runtime": ^7.16.3
     "@esbuild-plugins/node-resolve": ^0.1.4
@@ -5654,9 +5654,10 @@ __metadata:
     remark-frontmatter: ^4.0.1
     remark-mdx-frontmatter: ^1.1.1
     uuid: ^8.3.2
+    vfile: ^5.3.2
   peerDependencies:
-    esbuild: 0.11.x || 0.12.x || 0.13.x || 0.14.x
-  checksum: 8b20c023eac0cf8ed9f4da6d51159399b9262a60bcad21700305c956ac0984ef917cbefbaec1a295c9346a11b48f2e265491808288e72cb5dab00034d5c3f159
+    esbuild: 0.*
+  checksum: 3a7e9269d8a6913dc87e5f54856b727230da02b0ae2858dc38398b15480fbf7a62fe43955fb4be2dc9b024bf8e60e08c15611473827287321afe5711bec26d23
   languageName: node
   linkType: hard
 
@@ -8781,6 +8782,18 @@ __metadata:
     unist-util-stringify-position: ^3.0.0
     vfile-message: ^3.0.0
   checksum: 2382edc7c6e3502bca72bc95bc1ff0fe1852482e8a0ac257615f9ab12f32564d6f6a55da8756b74a900d26a247da5ca23a92ca7c9a18dbda2b0f87504ef0611f
+  languageName: node
+  linkType: hard
+
+"vfile@npm:^5.3.2":
+  version: 5.3.6
+  resolution: "vfile@npm:5.3.6"
+  dependencies:
+    "@types/unist": ^2.0.0
+    is-buffer: ^2.0.0
+    unist-util-stringify-position: ^3.0.0
+    vfile-message: ^3.0.0
+  checksum: 1aa5efff510bc6621ff8a7dc6513110529a11a8d665b44f169cc2a2b6bfa4f312efa00bfe86ca20e506538ff2915c8e538a664bd02a06419421ff964844fbe94
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
fix #335 

mdx-bundler's latest version is changed 9.0.1 to 9.2.1. And its peerDependencies are changed like this.

```json
// version 9.0.1
  "peerDependencies": {
    "esbuild": "0.11.x || 0.12.x || 0.13.x || 0.14.x"
  },

// version 9.2.1
  "peerDependencies": {
    "esbuild": "0.*"
  },
```

So I changed contenelayer's mdx-bundler version to 9.2.1. I expect that it fix #335 issue.