### PR TITLE
Validate if fields exist before reading

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,6 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["examples-*"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "useCalculatedVersionForSnapshots": true
   }

--- a/.changeset/twelve-emus-refuse.md
+++ b/.changeset/twelve-emus-refuse.md
@@ -1,0 +1,5 @@
+---
+'@contentlayer/source-files': patch
+---
+
+Handle empty files when using `contentType: Data`

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "./packages/*",
     "./examples/*"
   ],
+  "version": "0.3.1",
   "scripts": {
     "postinstall": "ts-patch install && ts-patch --persist",
     "test": "CI=true VITEST_SEGFAULT_RETRY=3 yarn workspaces foreach --parallel run test",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "./packages/*",
     "./examples/*"
   ],
-  "version": "0.3.1",
   "scripts": {
     "postinstall": "ts-patch install && ts-patch --persist",
     "test": "CI=true VITEST_SEGFAULT_RETRY=3 yarn workspaces foreach --parallel run test",

--- a/packages/@contentlayer/source-files/src/fetchData/validateDocumentData.ts
+++ b/packages/@contentlayer/source-files/src/fetchData/validateDocumentData.ts
@@ -125,6 +125,10 @@ const getDocumentDefName = ({
   filePathPatternMap: FilePathPatternMap
   options: core.PluginOptions
 }): string | undefined => {
+  // Check if the document have fields
+  if (!rawContent.fields) {
+    return undefined;
+  }
   // first check if provided document has a type field value
   const typeFieldName = options.fieldOptions.typeFieldName
   const typeFieldValue = rawContent.fields[typeFieldName]
@@ -190,12 +194,12 @@ const validateFieldData = ({
         return Array.isArray(rawFieldData)
           ? O.none
           : O.some(
-              new FetchDataError.IncompatibleFieldDataError({
-                incompatibleFieldData: [[fieldDef.name, rawFieldData]],
-                documentFilePath,
-                documentTypeDef,
-              }),
-            )
+            new FetchDataError.IncompatibleFieldDataError({
+              incompatibleFieldData: [[fieldDef.name, rawFieldData]],
+              documentFilePath,
+              documentTypeDef,
+            }),
+          )
       // TODO also check for references in lists
       case 'reference':
         if (typeof rawFieldData === 'string') {


### PR DESCRIPTION
This pull request is to handle empty yaml files when we use contentType: data. It is to sole the issue #361 

As `rawContent.fields`  is empty, during validation phase, a simple return fix it. 