### PR TITLE
Fix ts-patch --persist deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "./examples/*"
   ],
   "scripts": {
-    "postinstall": "ts-patch install && ts-patch --persist",
+    "postinstall": "ts-patch install",
+    "prepare": "ts-patch install -s",
     "test": "CI=true VITEST_SEGFAULT_RETRY=3 yarn workspaces foreach --parallel run test",
     "build": "run build:clean && run build:ts && yarn workspace next-contentlayer run prepack",
     "build:ts": "tsc --build tsconfig.all.json",


### PR DESCRIPTION
With the new version of TS-patch the argument --persit doesn't hexist anymore. 

This PR switch to the prepare command in the package.json