### PR TITLE
Replace `faker` library with `@faker-js/faker`

### DIFF
--- a/packages/@contentlayer/source-files/package.json
+++ b/packages/@contentlayer/source-files/package.json
@@ -41,12 +41,11 @@
     "zod": "^3.20.2"
   },
   "devDependencies": {
-    "@types/faker": "^5.5.8",
+    "@faker-js/faker": "^7.6.0",
     "@types/micromatch": "^4.0.2",
     "@types/node": "^18.11.18",
     "@types/sharp": "^0.31.1",
     "@types/yaml": "^1.9.7",
-    "faker": "^5.5.3",
     "sharp": "^0.31.3",
     "vite": "^4.0.4",
     "vitest": "0.27.1"

--- a/packages/@contentlayer/source-files/src/__test__/errors/aggregate.spec.ts
+++ b/packages/@contentlayer/source-files/src/__test__/errors/aggregate.spec.ts
@@ -35,22 +35,20 @@ test('CouldNotDetermineDocumentTypeError: should print 4 errors', async () => {
     documentCount: 42,
   })
 
-  expect(errorString).toMatchInlineSnapshot(
-    `
+  expect(errorString).toMatchInlineSnapshot(`
     "Warning: Found 4 problems in 42 documents.
 
      └── Couldn't determine the document type for 4 documents. (Skipping documents)
          
          Please either define a filePathPattern for the given document type definition or provide a valid value for the type field (i.e. the field \\"type\\" needs to be one of the following document type names: TypeA, TypeB).
          
-         • docs/global_rupee_sensor.md
-         • docs/administrator_missouri_synergize.md
-         • docs/card_balanced.md
-         • docs/card_table.md
+         • docs/killer_handcrafted_synthesize.md
+         • docs/redundant_silver_card.md
+         • docs/maryland_market.md
+         • docs/content_steel_coordinator.md
          
     "
-  `,
-  )
+  `)
 })
 
 test('CouldNotDetermineDocumentTypeError: should print 24 errors - truncated', async () => {
@@ -63,39 +61,37 @@ test('CouldNotDetermineDocumentTypeError: should print 24 errors - truncated', a
     documentCount: 81,
   })
 
-  expect(errorString).toMatchInlineSnapshot(
-    `
+  expect(errorString).toMatchInlineSnapshot(`
     "Warning: Found 24 problems in 81 documents.
 
      └── Couldn't determine the document type for 24 documents. (Skipping documents)
          
          Please either define a filePathPattern for the given document type definition or provide a valid value for the type field (i.e. the field \\"type\\" needs to be one of the following document type names: TypeA, TypeB).
          
-         • docs/global_rupee_sensor.md
-         • docs/administrator_missouri_synergize.md
-         • docs/card_balanced.md
-         • docs/card_table.md
-         • docs/poland.md
-         • docs/withdrawal_buckinghamshire.md
-         • docs/synergistic_monitoring.md
-         • docs/enterprise_wide_orchestrator.md
-         • docs/index.md
-         • docs/shoes_markets.md
-         • docs/deliverables_palladium_berkshire.md
-         • docs/plastic_berkshire.md
-         • docs/future_berkshire_open_architected.md
-         • docs/hack_synthesizing.md
-         • docs/italy.md
-         • docs/focus.md
-         • docs/vatu_impactful_islands.md
-         • docs/account_sudan_incredible.md
-         • docs/digitized_borders_sleek.md
-         • docs/account.md
+         • docs/killer_handcrafted_synthesize.md
+         • docs/redundant_silver_card.md
+         • docs/maryland_market.md
+         • docs/content_steel_coordinator.md
+         • docs/rhenium_grocery.md
+         • docs/northeast.md
+         • docs/system_paradigm_hatchback.md
+         • docs/degree_tin_bandwidth.md
+         • docs/elegant_plight.md
+         • docs/southeast_antillian_tan.md
+         • docs/bulgarian.md
+         • docs/dobra_safely_lie.md
+         • docs/scsi_dicta.md
+         • docs/target.md
+         • docs/facilitator_hence.md
+         • docs/online.md
+         • docs/sleek_omani_missouri.md
+         • docs/plum_forint_east.md
+         • docs/account_truthful.md
+         • docs/indexing.md
          • ... 4 more documents (Use the --verbose CLI option to show all documents)
          
     "
-  `,
-  )
+  `)
 })
 
 test('CouldNotDetermineDocumentTypeError: should print 24 errors - full', async () => {
@@ -109,42 +105,40 @@ test('CouldNotDetermineDocumentTypeError: should print 24 errors - full', async 
     verbose: true,
   })
 
-  expect(errorString).toMatchInlineSnapshot(
-    `
+  expect(errorString).toMatchInlineSnapshot(`
     "Warning: Found 24 problems in 81 documents.
 
      └── Couldn't determine the document type for 24 documents. (Skipping documents)
          
          Please either define a filePathPattern for the given document type definition or provide a valid value for the type field (i.e. the field \\"type\\" needs to be one of the following document type names: TypeA, TypeB).
          
-         • docs/global_rupee_sensor.md
-         • docs/administrator_missouri_synergize.md
-         • docs/card_balanced.md
-         • docs/card_table.md
-         • docs/poland.md
-         • docs/withdrawal_buckinghamshire.md
-         • docs/synergistic_monitoring.md
-         • docs/enterprise_wide_orchestrator.md
-         • docs/index.md
-         • docs/shoes_markets.md
-         • docs/deliverables_palladium_berkshire.md
-         • docs/plastic_berkshire.md
-         • docs/future_berkshire_open_architected.md
-         • docs/hack_synthesizing.md
-         • docs/italy.md
-         • docs/focus.md
-         • docs/vatu_impactful_islands.md
-         • docs/account_sudan_incredible.md
-         • docs/digitized_borders_sleek.md
-         • docs/account.md
-         • docs/health_user_ball.md
-         • docs/boliviano_buckinghamshire_cuba.md
-         • docs/internal_array.md
-         • docs/front_line.md
+         • docs/killer_handcrafted_synthesize.md
+         • docs/redundant_silver_card.md
+         • docs/maryland_market.md
+         • docs/content_steel_coordinator.md
+         • docs/rhenium_grocery.md
+         • docs/northeast.md
+         • docs/system_paradigm_hatchback.md
+         • docs/degree_tin_bandwidth.md
+         • docs/elegant_plight.md
+         • docs/southeast_antillian_tan.md
+         • docs/bulgarian.md
+         • docs/dobra_safely_lie.md
+         • docs/scsi_dicta.md
+         • docs/target.md
+         • docs/facilitator_hence.md
+         • docs/online.md
+         • docs/sleek_omani_missouri.md
+         • docs/plum_forint_east.md
+         • docs/account_truthful.md
+         • docs/indexing.md
+         • docs/awesome_global_unleash.md
+         • docs/wooden_health_dolorem.md
+         • docs/circuit.md
+         • docs/factors.md
          
     "
-  `,
-  )
+  `)
 })
 
 test('CouldNotDetermineDocumentTypeError: should ignore the errors', async () => {
@@ -171,24 +165,22 @@ test('MissingRequiredFieldsError: should print 4 warnings', async () => {
     documentCount: 42,
   })
 
-  expect(errorString).toMatchInlineSnapshot(
-    `
+  expect(errorString).toMatchInlineSnapshot(`
     "Warning: Found 4 problems in 42 documents.
 
      └── Missing required fields for 4 documents. (Skipping documents)
          
-         • \\"docs/global_rupee_sensor.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/killer_handcrafted_synthesize.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/administrator_missouri_synergize.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/redundant_silver_card.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/card_balanced.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/maryland_market.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/card_table.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/content_steel_coordinator.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
          
     "
-  `,
-  )
+  `)
 })
 
 test('MissingRequiredFieldsError: should fail because of singleton', async () => {
@@ -202,24 +194,22 @@ test('MissingRequiredFieldsError: should fail because of singleton', async () =>
     documentCount: 42,
   })
 
-  expect(errorString).toMatchInlineSnapshot(
-    `
+  expect(errorString).toMatchInlineSnapshot(`
     "Error: Found 4 problems in 42 documents.
 
      └── Missing required fields for 4 documents.
          
-         • \\"docs/global_rupee_sensor.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/killer_handcrafted_synthesize.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/administrator_missouri_synergize.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/redundant_silver_card.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/card_balanced.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/maryland_market.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/card_table.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/content_steel_coordinator.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
          
     "
-  `,
-  )
+  `)
 })
 
 test('ExtraFieldDataError: should print warning', async () => {
@@ -232,20 +222,18 @@ test('ExtraFieldDataError: should print warning', async () => {
     documentCount: 42,
   })
 
-  expect(errorString).toMatchInlineSnapshot(
-    `
+  expect(errorString).toMatchInlineSnapshot(`
     "Warning: Found 2 problems in 42 documents.
 
      └──   2 documents contain field data which isn't defined in the document type definition.
          
-         • \\"docs/global_rupee_sensor.md\\" of type \\"TypeB\\" has the following extra fields:
+         • \\"docs/killer_handcrafted_synthesize.md\\" of type \\"TypeB\\" has the following extra fields:
            • someKey: \\"someVal\\" 
-         • \\"docs/administrator_missouri_synergize.md\\" of type \\"TypeB\\" has the following extra fields:
+         • \\"docs/redundant_silver_card.md\\" of type \\"TypeB\\" has the following extra fields:
            • someOtherKey: 42 
          
     "
-  `,
-  )
+  `)
 })
 
 test('ExtraFieldDataError: should print error', async () => {
@@ -258,20 +246,18 @@ test('ExtraFieldDataError: should print error', async () => {
     documentCount: 42,
   })
 
-  expect(errorString).toMatchInlineSnapshot(
-    `
+  expect(errorString).toMatchInlineSnapshot(`
     "Error: Found 2 problems in 42 documents.
 
      └──   2 documents contain field data which isn't defined in the document type definition.
          
-         • \\"docs/global_rupee_sensor.md\\" of type \\"TypeB\\" has the following extra fields:
+         • \\"docs/killer_handcrafted_synthesize.md\\" of type \\"TypeB\\" has the following extra fields:
            • someKey: \\"someVal\\" 
-         • \\"docs/administrator_missouri_synergize.md\\" of type \\"TypeB\\" has the following extra fields:
+         • \\"docs/redundant_silver_card.md\\" of type \\"TypeB\\" has the following extra fields:
            • someOtherKey: 42 
          
     "
-  `,
-  )
+  `)
 })
 
 test('MissingRequiredFieldsError: should print 24 errors - truncated', async () => {
@@ -284,57 +270,55 @@ test('MissingRequiredFieldsError: should print 24 errors - truncated', async () 
     documentCount: 81,
   })
 
-  expect(errorString).toMatchInlineSnapshot(
-    `
+  expect(errorString).toMatchInlineSnapshot(`
     "Warning: Found 24 problems in 81 documents.
 
      └── Missing required fields for 24 documents. (Skipping documents)
          
-         • \\"docs/global_rupee_sensor.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/killer_handcrafted_synthesize.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/administrator_missouri_synergize.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/redundant_silver_card.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/card_balanced.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/maryland_market.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/card_table.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/content_steel_coordinator.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/poland.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/rhenium_grocery.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/withdrawal_buckinghamshire.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/northeast.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/synergistic_monitoring.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/system_paradigm_hatchback.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/enterprise_wide_orchestrator.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/degree_tin_bandwidth.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/index.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/elegant_plight.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/shoes_markets.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/southeast_antillian_tan.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/deliverables_palladium_berkshire.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/bulgarian.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/plastic_berkshire.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/dobra_safely_lie.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/future_berkshire_open_architected.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/scsi_dicta.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/hack_synthesizing.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/target.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/italy.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/facilitator_hence.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/focus.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/online.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/vatu_impactful_islands.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/sleek_omani_missouri.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/account_sudan_incredible.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/plum_forint_east.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/digitized_borders_sleek.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/account_truthful.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/account.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/indexing.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
          • ... 4 more documents (Use the --verbose CLI option to show all documents)
          
     "
-  `,
-  )
+  `)
 })
 
 test('mix of different errors: some', async () => {
@@ -347,29 +331,27 @@ test('mix of different errors: some', async () => {
     documentCount: 42,
   })
 
-  expect(errorString).toMatchInlineSnapshot(
-    `
+  expect(errorString).toMatchInlineSnapshot(`
     "Warning: Found 6 problems in 42 documents.
 
      ├── Couldn't determine the document type for 4 documents. (Skipping documents)
      │   
      │   Please either define a filePathPattern for the given document type definition or provide a valid value for the type field (i.e. the field \\"type\\" needs to be one of the following document type names: TypeA, TypeB).
      │   
-     │   • docs/global_rupee_sensor.md
-     │   • docs/administrator_missouri_synergize.md
-     │   • docs/card_balanced.md
-     │   • docs/card_table.md
+     │   • docs/killer_handcrafted_synthesize.md
+     │   • docs/redundant_silver_card.md
+     │   • docs/maryland_market.md
+     │   • docs/content_steel_coordinator.md
      │   
      └── Couldn't find document type definitions provided by name for 2 documents. (Skipping documents)
          
          Please use one of the following document type names: TypeA, TypeB.
          
-         • docs/poland.md (Used type name: \\"TypeB\\")
-         • docs/withdrawal_buckinghamshire.md (Used type name: \\"TypeB\\")
+         • docs/rhenium_grocery.md (Used type name: \\"TypeB\\")
+         • docs/northeast.md (Used type name: \\"TypeB\\")
          
     "
-  `,
-  )
+  `)
 })
 
 test('mix of different errors: with extra field data', async () => {
@@ -385,34 +367,32 @@ test('mix of different errors: with extra field data', async () => {
     documentCount: 42,
   })
 
-  expect(errorString).toMatchInlineSnapshot(
-    `
+  expect(errorString).toMatchInlineSnapshot(`
     "Warning: Found 7 problems in 42 documents.
 
      ├── Couldn't determine the document type for 4 documents. (Skipping documents)
      │   
      │   Please either define a filePathPattern for the given document type definition or provide a valid value for the type field (i.e. the field \\"type\\" needs to be one of the following document type names: TypeA, TypeB).
      │   
-     │   • docs/global_rupee_sensor.md
-     │   • docs/administrator_missouri_synergize.md
-     │   • docs/card_balanced.md
-     │   • docs/card_table.md
+     │   • docs/killer_handcrafted_synthesize.md
+     │   • docs/redundant_silver_card.md
+     │   • docs/maryland_market.md
+     │   • docs/content_steel_coordinator.md
      │   
      ├── Couldn't find document type definitions provided by name for 2 documents. (Skipping documents)
      │   
      │   Please use one of the following document type names: TypeA, TypeB.
      │   
-     │   • docs/poland.md (Used type name: \\"TypeB\\")
-     │   • docs/withdrawal_buckinghamshire.md (Used type name: \\"TypeB\\")
+     │   • docs/rhenium_grocery.md (Used type name: \\"TypeB\\")
+     │   • docs/northeast.md (Used type name: \\"TypeB\\")
      │   
      └──   1 documents contain field data which isn't defined in the document type definition.
          
-         • \\"docs/synergistic_monitoring.md\\" of type \\"TypeB\\" has the following extra fields:
+         • \\"docs/system_paradigm_hatchback.md\\" of type \\"TypeB\\" has the following extra fields:
            • someKey: \\"someVal\\" 
          
     "
-  `,
-  )
+  `)
 })
 
 test('mix of different errors: other', async () => {
@@ -434,45 +414,43 @@ test('mix of different errors: other', async () => {
     documentCount: 42,
   })
 
-  expect(errorString).toMatchInlineSnapshot(
-    `
+  expect(errorString).toMatchInlineSnapshot(`
     "Error: Found 12 problems in 42 documents.
 
      ├── Couldn't determine the document type for 4 documents. (Skipping documents)
      │   
      │   Please either define a filePathPattern for the given document type definition or provide a valid value for the type field (i.e. the field \\"type\\" needs to be one of the following document type names: TypeA, TypeB).
      │   
-     │   • docs/global_rupee_sensor.md
-     │   • docs/administrator_missouri_synergize.md
-     │   • docs/card_balanced.md
-     │   • docs/card_table.md
+     │   • docs/killer_handcrafted_synthesize.md
+     │   • docs/redundant_silver_card.md
+     │   • docs/maryland_market.md
+     │   • docs/content_steel_coordinator.md
      │   
      ├── Couldn't find document type definitions provided by name for 2 documents. (Skipping documents)
      │   
      │   Please use one of the following document type names: TypeA, TypeB.
      │   
-     │   • docs/poland.md (Used type name: \\"TypeB\\")
-     │   • docs/withdrawal_buckinghamshire.md (Used type name: \\"TypeB\\")
+     │   • docs/rhenium_grocery.md (Used type name: \\"TypeB\\")
+     │   • docs/northeast.md (Used type name: \\"TypeB\\")
      │   
      ├── Encountered unexpected errors while processing of 2 documents. This is possibly a bug in Contentlayer. Please open an issue.
      │   
-     │   • \\"docs/synergistic_monitoring.md\\": Error: Some problem happened: Try to calculate the SSL card, maybe it will input the open-source matrix!
-     │   • \\"docs/index.md\\": Error: Some problem happened: You can't copy the system without hacking the online CSS protocol!
+     │   • \\"docs/system_paradigm_hatchback.md\\": Error: Some problem happened: The SSD monitor is down, calculate the cross-platform system so we can navigate the SAS card!
+     │   • \\"docs/gorgeous_rich.md\\": Error: Some problem happened: The SSL system is down, override the 1080p driver so we can connect the API system!
      │   
      ├── Error during computed field exection for 1 documents. (Skipping documents)
      │   
-     │   • \\"docs/deliverables_palladium_berkshire.md\\" failed with Error: Some problem happened: Use the virtual RAM sensor, then you can synthesize the virtual interface!
+     │   • \\"docs/bulgarian.md\\" failed with Error: Some problem happened: I'll generate the solid state IP feed, that should capacitor the SSD firewall!
      │   
      └── Missing required fields for 3 documents. (Skipping documents)
          
-         • \\"docs/future_berkshire_open_architected.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/intranet_northwest.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/hack_synthesizing.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/redundant.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
-         • \\"docs/italy.md\\" (of type \\"TypeB\\") is missing the following required fields:
+         • \\"docs/useful_bronze_online.md\\" (of type \\"TypeB\\") is missing the following required fields:
            • someField: string
          
     "
-  `,
-  )
+  `)
 })

--- a/packages/@contentlayer/source-files/src/__test__/errors/utils.ts
+++ b/packages/@contentlayer/source-files/src/__test__/errors/utils.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path'
 import type * as core from '@contentlayer/core'
 import type { RelativePosixFilePath } from '@contentlayer/utils'
 import { singleItem, unknownToRelativePosixFilePath } from '@contentlayer/utils'
-import faker from 'faker'
+import { faker } from '@faker-js/faker'
 
 import { FetchDataError } from '../../errors/index.js'
 
@@ -65,7 +65,7 @@ export const makeErrors = (
   faker.seed(123)
 
   const documentTypeNames = Object.keys(schemaDef.documentTypeDefMap)
-  const documentTypeName = faker.random.arrayElement(documentTypeNames)
+  const documentTypeName = faker.helpers.arrayElement(documentTypeNames)
   const documentTypeDef = schemaDef.documentTypeDefMap[documentTypeName]!
 
   doNTimes(countRecord.CouldNotDetermineDocumentTypeError, () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -364,13 +364,12 @@ __metadata:
   dependencies:
     "@contentlayer/core": "workspace:*"
     "@contentlayer/utils": "workspace:*"
-    "@types/faker": ^5.5.8
+    "@faker-js/faker": ^7.6.0
     "@types/micromatch": ^4.0.2
     "@types/node": ^18.11.18
     "@types/sharp": ^0.31.1
     "@types/yaml": ^1.9.7
     chokidar: ^3.5.3
-    faker: ^5.5.3
     fast-glob: ^3.2.12
     gray-matter: ^4.0.3
     imagescript: ^1.2.15
@@ -684,6 +683,13 @@ __metadata:
     minimatch: ^3.1.2
     strip-json-comments: ^3.1.1
   checksum: cd3e5a8683db604739938b1c1c8b77927dc04fce3e28e0c88e7f2cd4900b89466baf83dfbad76b2b9e4d2746abdd00dd3f9da544d3e311633d8693f327d04cd7
+  languageName: node
+  linkType: hard
+
+"@faker-js/faker@npm:^7.6.0":
+  version: 7.6.0
+  resolution: "@faker-js/faker@npm:7.6.0"
+  checksum: 942af6221774e8c98a0eb6bc75265e05fb81a941170377666c3439aab9495dd321d6beedc5406f07e6ad44262b3e43c20961f666d116ad150b78e7437dd1bb2b
   languageName: node
   linkType: hard
 
@@ -1601,13 +1607,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/faker@npm:^5.5.8":
-  version: 5.5.9
-  resolution: "@types/faker@npm:5.5.9"
-  checksum: c2cbd082abe29047c89cf29b86257e582d2a177a9d1ed3abf99aa1cc025d5e8a3d201dfaddf8441bfcc57ed43e4da80e666951e1c23a5b759ac441a5855b5c36
-  languageName: node
-  linkType: hard
-
 "@types/hast@npm:^2.0.0":
   version: 2.3.4
   resolution: "@types/hast@npm:2.3.4"
@@ -1760,7 +1759,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:18.0.26, @types/react@npm:^18.0.26":
+"@types/react@npm:^18.0.26":
   version: 18.0.26
   resolution: "@types/react@npm:18.0.26"
   dependencies:
@@ -1969,37 +1968,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-node@npm:^1.8.2":
-  version: 1.8.2
-  resolution: "acorn-node@npm:1.8.2"
-  dependencies:
-    acorn: ^7.0.0
-    acorn-walk: ^7.0.0
-    xtend: ^4.0.2
-  checksum: 02e1564a1ccf8bd1fcefcd01235398af4a9effaf032c5397994ddd275590a72894cb3e26e4b82579ccdda1e48ade7486aef61e771ddae3563ca452b927f443d8
-  languageName: node
-  linkType: hard
-
-"acorn-walk@npm:^7.0.0":
-  version: 7.2.0
-  resolution: "acorn-walk@npm:7.2.0"
-  checksum: 9252158a79b9d92f1bc0dd6acc0fcfb87a67339e84bcc301bb33d6078936d27e35d606b4d35626d2962cd43c256d6f27717e70cbe15c04fff999ab0b2260b21f
-  languageName: node
-  linkType: hard
-
 "acorn-walk@npm:^8.1.1, acorn-walk@npm:^8.2.0":
   version: 8.2.0
   resolution: "acorn-walk@npm:8.2.0"
   checksum: 1715e76c01dd7b2d4ca472f9c58968516a4899378a63ad5b6c2d668bba8da21a71976c14ec5f5b75f887b6317c4ae0b897ab141c831d741dc76024d8745f1ad1
-  languageName: node
-  linkType: hard
-
-"acorn@npm:^7.0.0":
-  version: 7.4.1
-  resolution: "acorn@npm:7.4.1"
-  bin:
-    acorn: bin/acorn
-  checksum: 1860f23c2107c910c6177b7b7be71be350db9e1080d814493fae143ae37605189504152d1ba8743ba3178d0b37269ce1ffc42b101547fdc1827078f82671e407
   languageName: node
   linkType: hard
 
@@ -2161,13 +2133,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"arg@npm:^5.0.2":
-  version: 5.0.2
-  resolution: "arg@npm:5.0.2"
-  checksum: 6c69ada1a9943d332d9e5382393e897c500908d91d5cb735a01120d5f71daf1b339b7b8980cbeaba8fd1afc68e658a739746179e4315a26e8a28951ff9930078
-  languageName: node
-  linkType: hard
-
 "argparse@npm:^1.0.7":
   version: 1.0.10
   resolution: "argparse@npm:1.0.10"
@@ -2269,24 +2234,6 @@ __metadata:
   version: 1.0.0
   resolution: "at-least-node@npm:1.0.0"
   checksum: 463e2f8e43384f1afb54bc68485c436d7622acec08b6fad269b421cb1d29cebb5af751426793d0961ed243146fe4dc983402f6d5a51b720b277818dbf6f2e49e
-  languageName: node
-  linkType: hard
-
-"autoprefixer@npm:^10.4.13":
-  version: 10.4.13
-  resolution: "autoprefixer@npm:10.4.13"
-  dependencies:
-    browserslist: ^4.21.4
-    caniuse-lite: ^1.0.30001426
-    fraction.js: ^4.2.0
-    normalize-range: ^0.1.2
-    picocolors: ^1.0.0
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.1.0
-  bin:
-    autoprefixer: bin/autoprefixer
-  checksum: dcb1cb7ae96a3363d65d82e52f9a0a7d8c982256f6fd032d7e1ec311f099c23acfebfd517ff8e96bf93f716a66c4ea2b80c60aa19efd2f474ce434bd75ef7b79
   languageName: node
   linkType: hard
 
@@ -2420,20 +2367,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.21.4":
-  version: 4.21.4
-  resolution: "browserslist@npm:4.21.4"
-  dependencies:
-    caniuse-lite: ^1.0.30001400
-    electron-to-chromium: ^1.4.251
-    node-releases: ^2.0.6
-    update-browserslist-db: ^1.0.9
-  bin:
-    browserslist: cli.js
-  checksum: 4af3793704dbb4615bcd29059ab472344dc7961c8680aa6c4bb84f05340e14038d06a5aead58724eae69455b8fade8b8c69f1638016e87e5578969d74c078b79
-  languageName: node
-  linkType: hard
-
 "buffer-from@npm:^1.0.0":
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
@@ -2511,13 +2444,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camelcase-css@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "camelcase-css@npm:2.0.1"
-  checksum: 1cec2b3b3dcb5026688a470b00299a8db7d904c4802845c353dbd12d9d248d3346949a814d83bfd988d4d2e5b9904c07efe76fecd195a1d4f05b543e7c0b56b1
-  languageName: node
-  linkType: hard
-
 "camelcase-keys@npm:^6.2.2":
   version: 6.2.2
   resolution: "camelcase-keys@npm:6.2.2"
@@ -2543,17 +2469,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001400, caniuse-lite@npm:^1.0.30001406":
+"caniuse-lite@npm:^1.0.30001406":
   version: 1.0.30001415
   resolution: "caniuse-lite@npm:1.0.30001415"
   checksum: cd7ca55243a2d556aed2c2da4638643b032f88bbbd745ba7cdaf72fb2131812c63816f615dec704762ab385364387ce885953fa3a4d7555ea219336303dcc06f
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001426":
-  version: 1.0.30001431
-  resolution: "caniuse-lite@npm:1.0.30001431"
-  checksum: bc8ab55cd194e240152946b54bfaff7456180cc018674fc7ed134f4f502192405f6643f422feaa0a5e7cc02b5bac564cfac7771ac6d29f5d129482fcfe335ba1
   languageName: node
   linkType: hard
 
@@ -2838,7 +2757,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-name@npm:^1.0.0, color-name@npm:^1.1.4, color-name@npm:~1.1.4":
+"color-name@npm:^1.0.0, color-name@npm:~1.1.4":
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: b0445859521eb4021cd0fb0cc1a75cecf67fceecae89b63f62b201cca8d345baf8b952c966862a9d9a2632987d4f6581f0ec8d957dfacece86f0a7919316f610
@@ -3091,15 +3010,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssesc@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "cssesc@npm:3.0.0"
-  bin:
-    cssesc: bin/cssesc
-  checksum: f8c4ababffbc5e2ddf2fa9957dda1ee4af6048e22aeda1869d0d00843223c1b13ad3f5d88b51caa46c994225eacb636b764eb807a8883e2fb6f99b4f4e8c48b2
-  languageName: node
-  linkType: hard
-
 "csstype@npm:^3.0.2":
   version: 3.1.0
   resolution: "csstype@npm:3.1.0"
@@ -3144,13 +3054,6 @@ __metadata:
   version: 4.0.0
   resolution: "data-uri-to-buffer@npm:4.0.0"
   checksum: a010653869abe8bb51259432894ac62c52bf79ad761d418d94396f48c346f2ae739c46b254e8bb5987bded8a653d467db1968db3a69bab1d33aa5567baa5cfc7
-  languageName: node
-  linkType: hard
-
-"date-fns@npm:2.29.3":
-  version: 2.29.3
-  resolution: "date-fns@npm:2.29.3"
-  checksum: e01cf5b62af04e05dfff921bb9c9933310ed0e1ae9a81eb8653452e64dc841acf7f6e01e1a5ae5644d0337e9a7f936175fd2cb6819dc122fdd9c5e86c56be484
   languageName: node
   linkType: hard
 
@@ -3261,13 +3164,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"defined@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "defined@npm:1.0.0"
-  checksum: 77672997c5001773371c4dbcce98da0b3dc43089d6da2ad87c4b800adb727633cea8723ea3889fe0c2112a2404e2fd07e3bfd0e55f7426aa6441d8992045dbd5
-  languageName: node
-  linkType: hard
-
 "delegates@npm:^1.0.0":
   version: 1.0.0
   resolution: "delegates@npm:1.0.0"
@@ -3310,19 +3206,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detective@npm:^5.2.1":
-  version: 5.2.1
-  resolution: "detective@npm:5.2.1"
-  dependencies:
-    acorn-node: ^1.8.2
-    defined: ^1.0.0
-    minimist: ^1.2.6
-  bin:
-    detective: bin/detective.js
-  checksum: dc4601bbc6be850edb3c2dab7a0eaf5a6169a15ad201679c66d40ea1986df816eeaecd590047f15b0780285f3eeea13b82dca0d4c52a47e744a571e326a72dc9
-  languageName: node
-  linkType: hard
-
 "didyoumean2@npm:^5.0.0":
   version: 5.0.0
   resolution: "didyoumean2@npm:5.0.0"
@@ -3331,13 +3214,6 @@ __metadata:
     fastest-levenshtein: ^1.0.12
     lodash.deburr: ^4.1.0
   checksum: 99935a1433d31595d7f7f7f2e12c582ee634a07913856b2f7fb85923b30e3cbb24e37bea8bbe3da6ec42ad030fdc8cd2e07cca326de517730f07dfea8e05a025
-  languageName: node
-  linkType: hard
-
-"didyoumean@npm:^1.2.2":
-  version: 1.2.2
-  resolution: "didyoumean@npm:1.2.2"
-  checksum: d5d98719d58b3c2fa59663c4c42ba9716f1fd01245c31d5fce31915bd3aa26e6aac149788e007358f778ebbd68a2256eb5973e8ca6f221df221ba060115acf2e
   languageName: node
   linkType: hard
 
@@ -3364,13 +3240,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dlv@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "dlv@npm:1.1.3"
-  checksum: d7381bca22ed11933a1ccf376db7a94bee2c57aa61e490f680124fa2d1cd27e94eba641d9f45be57caab4f9a6579de0983466f620a2cd6230d7ec93312105ae7
-  languageName: node
-  linkType: hard
-
 "doctrine@npm:^2.1.0":
   version: 2.1.0
   resolution: "doctrine@npm:2.1.0"
@@ -3386,13 +3255,6 @@ __metadata:
   dependencies:
     esutils: ^2.0.2
   checksum: fd7673ca77fe26cd5cba38d816bc72d641f500f1f9b25b83e8ce28827fe2da7ad583a8da26ab6af85f834138cf8dae9f69b0cd6ab925f52ddab1754db44d99ce
-  languageName: node
-  linkType: hard
-
-"electron-to-chromium@npm:^1.4.251":
-  version: 1.4.271
-  resolution: "electron-to-chromium@npm:1.4.271"
-  checksum: 8fcba3bb2001694f3a3d8639247866d05fbf1017fd48b294606b722e1e3379999e663163685ac1332d7c1a2b291950f46e4aba06e5c61b8300dce509ae06c6c7
   languageName: node
   linkType: hard
 
@@ -4001,13 +3863,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"faker@npm:^5.5.3":
-  version: 5.5.3
-  resolution: "faker@npm:5.5.3"
-  checksum: 684fd64c8d3897e54248f95b4f6319f75d97691b8500cd13adf4af2c28f9204f766c1d1aaa6b41338f0beaaa87256c3132f8708a1a8f189d122b92f6b98081c3
-  languageName: node
-  linkType: hard
-
 "fast-copy@npm:^2.1.0":
   version: 2.1.3
   resolution: "fast-copy@npm:2.1.3"
@@ -4203,13 +4058,6 @@ __metadata:
   dependencies:
     fetch-blob: ^3.1.2
   checksum: 82a34df292afadd82b43d4a740ce387bc08541e0a534358425193017bf9fb3567875dc5f69564984b1da979979b70703aa73dee715a17b6c229752ae736dd9db
-  languageName: node
-  linkType: hard
-
-"fraction.js@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "fraction.js@npm:4.2.0"
-  checksum: 8c76a6e21dedea87109d6171a0ac77afa14205794a565d71cb10d2925f629a3922da61bf45ea52dbc30bce4d8636dc0a27213a88cbd600eab047d82f9a3a94c5
   languageName: node
   linkType: hard
 
@@ -5276,7 +5124,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
+"js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
   checksum: 8a95213a5a77deb6cbe94d86340e8d9ace2b93bc367790b260101d2f36a2eaf4e4e22d9fa9cf459b38af3a32fb4190e638024cf82ec95ef708680e405ea7cc78
@@ -5398,13 +5246,6 @@ __metadata:
     prelude-ls: ^1.2.1
     type-check: ~0.4.0
   checksum: 12c5021c859bd0f5248561bf139121f0358285ec545ebf48bb3d346820d5c61a4309535c7f387ed7d84361cf821e124ce346c6b7cef8ee09a67c1473b46d0fc4
-  languageName: node
-  linkType: hard
-
-"lilconfig@npm:^2.0.5, lilconfig@npm:^2.0.6":
-  version: 2.0.6
-  resolution: "lilconfig@npm:2.0.6"
-  checksum: 40a3cd72f103b1be5975f2ac1850810b61d4053e20ab09be8d3aeddfe042187e1ba70b4651a7e70f95efa1642e7dc8b2ae395b317b7d7753b241b43cef7c0f7d
   languageName: node
   linkType: hard
 
@@ -5562,17 +5403,6 @@ __metadata:
   version: 3.0.1
   resolution: "longest-streak@npm:3.0.1"
   checksum: 3b59c4c04ce3c70f137e339c10d574026fa3a711c45dc0e69a63a2c0ac981e57f837e1d5b64b991eee5234c4fa46fa10886a20626fb739ed3b04b77bcf6d14a8
-  languageName: node
-  linkType: hard
-
-"loose-envify@npm:^1.1.0":
-  version: 1.4.0
-  resolution: "loose-envify@npm:1.4.0"
-  dependencies:
-    js-tokens: ^3.0.0 || ^4.0.0
-  bin:
-    loose-envify: cli.js
-  checksum: 6517e24e0cad87ec9888f500c5b5947032cdfe6ef65e1c1936a0c48a524b81e65542c9c3edc91c97d5bddc806ee2a985dbc79be89215d613b1de5db6d1cfe6f4
   languageName: node
   linkType: hard
 
@@ -6474,25 +6304,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next-contentlayer-example@workspace:examples/next-contentlayer-example":
-  version: 0.0.0-use.local
-  resolution: "next-contentlayer-example@workspace:examples/next-contentlayer-example"
-  dependencies:
-    "@types/react": 18.0.26
-    autoprefixer: ^10.4.13
-    contentlayer: latest
-    date-fns: 2.29.3
-    next: 13.1.2
-    next-contentlayer: latest
-    postcss: ^8.4.21
-    react: 18.2.0
-    react-dom: 18.2.0
-    tailwindcss: ^3.2.4
-    typescript: 4.9.4
-  languageName: unknown
-  linkType: soft
-
-"next-contentlayer@workspace:*, next-contentlayer@workspace:packages/next-contentlayer":
+"next-contentlayer@workspace:packages/next-contentlayer":
   version: 0.0.0-use.local
   resolution: "next-contentlayer@workspace:packages/next-contentlayer"
   dependencies:
@@ -6509,7 +6321,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"next@npm:13.1.2, next@npm:^13.1.2":
+"next@npm:^13.1.2":
   version: 13.1.2
   resolution: "next@npm:13.1.2"
   dependencies:
@@ -6657,13 +6469,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-releases@npm:^2.0.6":
-  version: 2.0.6
-  resolution: "node-releases@npm:2.0.6"
-  checksum: e86a926dc9fbb3b41b4c4a89d998afdf140e20a4e8dbe6c0a807f7b2948b42ea97d7fd3ad4868041487b6e9ee98409829c6e4d84a734a4215dff060a7fbeb4bf
-  languageName: node
-  linkType: hard
-
 "node-script-example@workspace:examples/node-script":
   version: 0.0.0-use.local
   resolution: "node-script-example@workspace:examples/node-script"
@@ -6718,13 +6523,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-range@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "normalize-range@npm:0.1.2"
-  checksum: 9b2f14f093593f367a7a0834267c24f3cb3e887a2d9809c77d8a7e5fd08738bcd15af46f0ab01cc3a3d660386f015816b5c922cea8bf2ee79777f40874063184
-  languageName: node
-  linkType: hard
-
 "npm-run-path@npm:^2.0.0":
   version: 2.0.2
   resolution: "npm-run-path@npm:2.0.2"
@@ -6743,13 +6541,6 @@ __metadata:
     gauge: ^4.0.3
     set-blocking: ^2.0.0
   checksum: ae238cd264a1c3f22091cdd9e2b106f684297d3c184f1146984ecbe18aaa86343953f26b9520dedd1b1372bc0316905b736c1932d778dbeb1fcf5a1001390e2a
-  languageName: node
-  linkType: hard
-
-"object-hash@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "object-hash@npm:3.0.0"
-  checksum: 80b4904bb3857c52cc1bfd0b52c0352532ca12ed3b8a6ff06a90cd209dfda1b95cee059a7625eb9da29537027f68ac4619363491eedb2f5d3dddbba97494fd6c
   languageName: node
   linkType: hard
 
@@ -7095,13 +6886,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pify@npm:^2.3.0":
-  version: 2.3.0
-  resolution: "pify@npm:2.3.0"
-  checksum: 9503aaeaf4577acc58642ad1d25c45c6d90288596238fb68f82811c08104c800e5a7870398e9f015d82b44ecbcbef3dc3d4251a1cbb582f6e5959fe09884b2ba
-  languageName: node
-  linkType: hard
-
 "pify@npm:^4.0.1":
   version: 4.0.1
   resolution: "pify@npm:4.0.1"
@@ -7129,76 +6913,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-import@npm:^14.1.0":
-  version: 14.1.0
-  resolution: "postcss-import@npm:14.1.0"
-  dependencies:
-    postcss-value-parser: ^4.0.0
-    read-cache: ^1.0.0
-    resolve: ^1.1.7
-  peerDependencies:
-    postcss: ^8.0.0
-  checksum: cd45d406e90f67cdab9524352e573cc6b4462b790934a05954e929a6653ebd31288ceebc8ce3c3ed7117ae672d9ebbec57df0bceec0a56e9b259c2e71d47ca86
-  languageName: node
-  linkType: hard
-
-"postcss-js@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "postcss-js@npm:4.0.0"
-  dependencies:
-    camelcase-css: ^2.0.1
-  peerDependencies:
-    postcss: ^8.3.3
-  checksum: 14be8a58670b4c5d037d40f179240a4f736d53530db727e2635638fa296bc4bff18149ca860928398aace422e55d07c9f5729eeccd395340944985199cdc82a5
-  languageName: node
-  linkType: hard
-
-"postcss-load-config@npm:^3.1.4":
-  version: 3.1.4
-  resolution: "postcss-load-config@npm:3.1.4"
-  dependencies:
-    lilconfig: ^2.0.5
-    yaml: ^1.10.2
-  peerDependencies:
-    postcss: ">=8.0.9"
-    ts-node: ">=9.0.0"
-  peerDependenciesMeta:
-    postcss:
-      optional: true
-    ts-node:
-      optional: true
-  checksum: 1c589504c2d90b1568aecae8238ab993c17dba2c44f848a8f13619ba556d26a1c09644d5e6361b5784e721e94af37b604992f9f3dc0483e687a0cc1cc5029a34
-  languageName: node
-  linkType: hard
-
-"postcss-nested@npm:6.0.0":
-  version: 6.0.0
-  resolution: "postcss-nested@npm:6.0.0"
-  dependencies:
-    postcss-selector-parser: ^6.0.10
-  peerDependencies:
-    postcss: ^8.2.14
-  checksum: 2105dc52cd19747058f1a46862c9e454b5a365ac2e7135fc1015d67a8fe98ada2a8d9ee578e90f7a093bd55d3994dd913ba5ff1d5e945b4ed9a8a2992ecc8f10
-  languageName: node
-  linkType: hard
-
-"postcss-selector-parser@npm:^6.0.10":
-  version: 6.0.10
-  resolution: "postcss-selector-parser@npm:6.0.10"
-  dependencies:
-    cssesc: ^3.0.0
-    util-deprecate: ^1.0.2
-  checksum: 46afaa60e3d1998bd7adf6caa374baf857cc58d3ff944e29459c9a9e4680a7fe41597bd5b755fc81d7c388357e9bf67c0251d047c640a09f148e13606b8a8608
-  languageName: node
-  linkType: hard
-
-"postcss-value-parser@npm:^4.0.0, postcss-value-parser@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "postcss-value-parser@npm:4.2.0"
-  checksum: 819ffab0c9d51cf0acbabf8996dffbfafbafa57afc0e4c98db88b67f2094cb44488758f06e5da95d7036f19556a4a732525e84289a425f4f6fd8e412a9d7442f
-  languageName: node
-  linkType: hard
-
 "postcss@npm:8.4.14, postcss@npm:^8.4.13":
   version: 8.4.14
   resolution: "postcss@npm:8.4.14"
@@ -7210,18 +6924,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.4.18":
-  version: 8.4.18
-  resolution: "postcss@npm:8.4.18"
-  dependencies:
-    nanoid: ^3.3.4
-    picocolors: ^1.0.0
-    source-map-js: ^1.0.2
-  checksum: 9349fd99849b2e3d2e134ff949b7770ecb12375f352723ce2bcc06167eba3850ea7844c1b191a85cd915d6a396b4e8ee9a5267e6cc5d8d003d0cbc7a97555d39
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.4.20, postcss@npm:^8.4.21":
+"postcss@npm:^8.4.20":
   version: 8.4.21
   resolution: "postcss@npm:8.4.21"
   dependencies:
@@ -7407,13 +7110,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"quick-lru@npm:^5.1.1":
-  version: 5.1.1
-  resolution: "quick-lru@npm:5.1.1"
-  checksum: a516faa25574be7947969883e6068dbe4aa19e8ef8e8e0fd96cddd6d36485e9106d85c0041a27153286b0770b381328f4072aa40d3b18a19f5f7d2b78b94b5ed
-  languageName: node
-  linkType: hard
-
 "rc@npm:^1.2.7":
   version: 1.2.8
   resolution: "rc@npm:1.2.8"
@@ -7425,36 +7121,6 @@ __metadata:
   bin:
     rc: ./cli.js
   checksum: 2e26e052f8be2abd64e6d1dabfbd7be03f80ec18ccbc49562d31f617d0015fbdbcf0f9eed30346ea6ab789e0fdfe4337f033f8016efdbee0df5354751842080e
-  languageName: node
-  linkType: hard
-
-"react-dom@npm:18.2.0":
-  version: 18.2.0
-  resolution: "react-dom@npm:18.2.0"
-  dependencies:
-    loose-envify: ^1.1.0
-    scheduler: ^0.23.0
-  peerDependencies:
-    react: ^18.2.0
-  checksum: 7d323310bea3a91be2965f9468d552f201b1c27891e45ddc2d6b8f717680c95a75ae0bc1e3f5cf41472446a2589a75aed4483aee8169287909fcd59ad149e8cc
-  languageName: node
-  linkType: hard
-
-"react@npm:18.2.0":
-  version: 18.2.0
-  resolution: "react@npm:18.2.0"
-  dependencies:
-    loose-envify: ^1.1.0
-  checksum: 88e38092da8839b830cda6feef2e8505dec8ace60579e46aa5490fc3dc9bba0bd50336507dc166f43e3afc1c42939c09fe33b25fae889d6f402721dcd78fca1b
-  languageName: node
-  linkType: hard
-
-"read-cache@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "read-cache@npm:1.0.0"
-  dependencies:
-    pify: ^2.3.0
-  checksum: cffc728b9ede1e0667399903f9ecaf3789888b041c46ca53382fa3a06303e5132774dc0a96d0c16aa702dbac1ea0833d5a868d414f5ab2af1e1438e19e6657c6
   languageName: node
   linkType: hard
 
@@ -7680,7 +7346,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.1.6, resolve@npm:^1.1.7, resolve@npm:^1.10.0, resolve@npm:^1.19.0, resolve@npm:^1.22.0, resolve@npm:^1.22.1":
+"resolve@npm:^1.1.6, resolve@npm:^1.10.0, resolve@npm:^1.19.0, resolve@npm:^1.22.0, resolve@npm:^1.22.1":
   version: 1.22.1
   resolution: "resolve@npm:1.22.1"
   dependencies:
@@ -7693,7 +7359,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@^1.1.6#~builtin<compat/resolve>, resolve@patch:resolve@^1.1.7#~builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>":
+"resolve@patch:resolve@^1.1.6#~builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>":
   version: 1.22.1
   resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
   dependencies:
@@ -7832,15 +7498,6 @@ __metadata:
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: cab8f25ae6f1434abee8d80023d7e72b598cf1327164ddab31003c51215526801e40b66c5e65d658a0af1e9d6478cadcb4c745f4bd6751f97d8644786c0978b0
-  languageName: node
-  linkType: hard
-
-"scheduler@npm:^0.23.0":
-  version: 0.23.0
-  resolution: "scheduler@npm:0.23.0"
-  dependencies:
-    loose-envify: ^1.1.0
-  checksum: d79192eeaa12abef860c195ea45d37cbf2bbf5f66e3c4dcd16f54a7da53b17788a70d109ee3d3dde1a0fd50e6a8fc171f4300356c5aee4fc0171de526bf35f8a
   languageName: node
   linkType: hard
 
@@ -8399,42 +8056,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tailwindcss@npm:^3.2.4":
-  version: 3.2.4
-  resolution: "tailwindcss@npm:3.2.4"
-  dependencies:
-    arg: ^5.0.2
-    chokidar: ^3.5.3
-    color-name: ^1.1.4
-    detective: ^5.2.1
-    didyoumean: ^1.2.2
-    dlv: ^1.1.3
-    fast-glob: ^3.2.12
-    glob-parent: ^6.0.2
-    is-glob: ^4.0.3
-    lilconfig: ^2.0.6
-    micromatch: ^4.0.5
-    normalize-path: ^3.0.0
-    object-hash: ^3.0.0
-    picocolors: ^1.0.0
-    postcss: ^8.4.18
-    postcss-import: ^14.1.0
-    postcss-js: ^4.0.0
-    postcss-load-config: ^3.1.4
-    postcss-nested: 6.0.0
-    postcss-selector-parser: ^6.0.10
-    postcss-value-parser: ^4.2.0
-    quick-lru: ^5.1.1
-    resolve: ^1.22.1
-  peerDependencies:
-    postcss: ^8.0.9
-  bin:
-    tailwind: lib/cli.js
-    tailwindcss: lib/cli.js
-  checksum: ec187d180c722ec4f57537f2216c7b21269b525f12aaf353cea464d939c3e6286a1221eb3e1206e45d1f015f296171309ad4d9952899b0245cd07d9500a9401f
-  languageName: node
-  linkType: hard
-
 "tar-fs@npm:^2.0.0, tar-fs@npm:^2.1.1":
   version: 2.1.1
   resolution: "tar-fs@npm:2.1.1"
@@ -8808,7 +8429,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.9.4, typescript@npm:^4.9.4":
+"typescript@npm:^4.9.4":
   version: 4.9.4
   resolution: "typescript@npm:4.9.4"
   bin:
@@ -8818,7 +8439,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@4.9.4#~builtin<compat/typescript>, typescript@patch:typescript@^4.9.4#~builtin<compat/typescript>":
+"typescript@patch:typescript@^4.9.4#~builtin<compat/typescript>":
   version: 4.9.4
   resolution: "typescript@patch:typescript@npm%3A4.9.4#~builtin<compat/typescript>::version=4.9.4&hash=a1c5e5"
   bin:
@@ -8982,20 +8603,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"update-browserslist-db@npm:^1.0.9":
-  version: 1.0.9
-  resolution: "update-browserslist-db@npm:1.0.9"
-  dependencies:
-    escalade: ^3.1.1
-    picocolors: ^1.0.0
-  peerDependencies:
-    browserslist: ">= 4.21.0"
-  bin:
-    browserslist-lint: cli.js
-  checksum: f625899b236f6a4d7f62b56be1b8da230c5563d1fef84d3ef148f2e1a3f11a5a4b3be4fd7e3703e51274c116194017775b10afb4de09eb2c0d09d36b90f1f578
-  languageName: node
-  linkType: hard
-
 "uri-js@npm:^4.2.2":
   version: 4.4.1
   resolution: "uri-js@npm:4.4.1"
@@ -9005,7 +8612,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"util-deprecate@npm:^1.0.1, util-deprecate@npm:^1.0.2":
+"util-deprecate@npm:^1.0.1":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
@@ -9420,13 +9027,6 @@ __metadata:
   version: 1.0.2
   resolution: "wrappy@npm:1.0.2"
   checksum: 159da4805f7e84a3d003d8841557196034155008f817172d4e986bd591f74aa82aa7db55929a54222309e01079a65a92a9e6414da5a6aa4b01ee44a511ac3ee5
-  languageName: node
-  linkType: hard
-
-"xtend@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "xtend@npm:4.0.2"
-  checksum: ac5dfa738b21f6e7f0dd6e65e1b3155036d68104e67e5d5d1bde74892e327d7e5636a076f625599dc394330a731861e87343ff184b0047fef1360a7ec0a5a36a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Addresses #217 

`@faker-js/faker` mostly works as a drop-in replacement.
Note that I had to regenerate some test snapshots due to changed random vocabulary.