### PR TITLE
Fix type resolution when using modern TypeScript module resolution

### DIFF
--- a/.changeset/small-readers-itch.md
+++ b/.changeset/small-readers-itch.md
@@ -1,0 +1,10 @@
+---
+'contentlayer': patch
+---
+
+Fix type resolution when using modern TypeScript module resolution
+
+Ensure types exported from `contentlayer/core`, `contentlayer/source-files`,
+and `contentlayer/client` that are imported into generated code resolve
+properly when TypeScript is configured with `moduleResolution` set to
+`nodenext` or `node16`.

--- a/packages/contentlayer/package.json
+++ b/packages/contentlayer/package.json
@@ -8,27 +8,13 @@
   },
   "exports": {
     "./package.json": "./package.json",
-    "./source-files": {
-      "import": "./dist/source-files/index.js"
-    },
-    "./source-files/schema": {
-      "import": "./dist/source-files/schema/index.js"
-    },
-    "./source-remote-files": {
-      "import": "./dist/source-remote-files/index.js"
-    },
-    "./client": {
-      "import": "./dist/client/index.js"
-    },
-    "./utils": {
-      "import": "./dist/utils/index.js"
-    },
-    "./utils/node": {
-      "import": "./dist/utils/node/index.js"
-    },
-    "./core": {
-      "import": "./dist/core/index.js"
-    }
+    "./source-files": "./dist/source-files/index.js",
+    "./source-files/schema": "./dist/source-files/schema/index.js",
+    "./source-remote-files": "./dist/source-remote-files/index.js",
+    "./client": "./dist/client/index.js",
+    "./utils": "./dist/utils/index.js",
+    "./utils/node": "./dist/utils/node/index.js",
+    "./core": "./dist/core/index.js"
   },
   "_typesVersions": "Not needed anymore once this issue is closed https://github.com/microsoft/TypeScript/issues/33079",
   "typesVersions": {


### PR DESCRIPTION
I'm gradually working towards ECMAScript modules in our design system monorepo. One of the first steps to enabling this is switching to `moduleResolution: nodenext` or `moduleResolution: node16` in our TypeScript configuration.

I've run into a couple snags related to Contentlayer because it only ships ESM, but the only true blocker I've come across so far is that the types don't resolve properly in the generated code. Specifying `default` conditions in the `exports` field fixes this without having to make any source changes.

### Before

|  Import |  Inference   |
|---|-----|
|  <img width="1044" alt="before-tip" src="https://user-images.githubusercontent.com/288160/217367105-6ccbb3ea-d4c9-4ea4-8a11-530c6249eca0.png"> |  <img width="1044" alt="before-inference" src="https://user-images.githubusercontent.com/288160/217367843-9561c9a1-04c8-4d35-a3ea-a29a25c43c70.png"> |


### After

| Import  |  Inference   |
|---|-----|
|  <img width="1044" alt="after-tip" src="https://user-images.githubusercontent.com/288160/217367338-fdd2e7e6-3972-4d3a-b13d-866bd0958580.png"> |   <img width="1044" alt="after-infer" src="https://user-images.githubusercontent.com/288160/217367386-a0dad4e8-ab44-4ec8-aa13-23f57a7a083b.png">  |
