### PR TITLE
fix: Add conditions to determine the next dev.

### DIFF
--- a/packages/next-contentlayer/src/index-cjs.ts
+++ b/packages/next-contentlayer/src/index-cjs.ts
@@ -29,7 +29,8 @@ module.exports.createContentlayerPlugin =
   (nextConfig: Partial<NextConfig> = {}): Partial<NextConfig> => {
     // could be either `next dev` or just `next`
     const isNextDev =
-      process.argv.includes('dev') || process.argv.some((_) => _.endsWith('bin/next') || _.endsWith('bin\\next'))
+      process.argv.includes("dev") ||
+      process.argv.some((_) => _.endsWith("bin/next") || _.endsWith("bin\\next") || _.includes("jest-worker"))
     const isBuild = process.argv.includes('build')
 
     return {

--- a/packages/next-contentlayer/src/index.ts
+++ b/packages/next-contentlayer/src/index.ts
@@ -29,7 +29,8 @@ export const createContentlayerPlugin =
   (nextConfig: Partial<NextConfig> = {}): Partial<NextConfig> => {
     // could be either `next dev` or just `next`
     const isNextDev =
-      process.argv.includes('dev') || process.argv.some((_) => _.endsWith('bin/next') || _.endsWith('bin\\next'))
+      process.argv.includes("dev") ||
+      process.argv.some((_) => _.endsWith("bin/next") || _.endsWith("bin\\next") || _.includes("jest-worker"))
     const isBuild = process.argv.includes('build')
 
     const { configPath } = pluginOptions


### PR DESCRIPTION
Since next@v13.2.5-canary.27, next dev has been using jest-worker to start the service.
This will cause contentlayer to not generate files when starting the service using next dev.

The update of 'next' is as follows.
https://github.com/vercel/next.js/pull/47208/files#diff-0ff576bd02e76f96680accff48ecbe4126a7f6bc4eafa547b6d44dee49bab770R166-R180

FIx #415 