### PR TITLE
fix: Change korean file name build result

### DIFF
--- a/packages/@contentlayer/core/src/generation/generate-dotpkg.ts
+++ b/packages/@contentlayer/core/src/generation/generate-dotpkg.ts
@@ -324,7 +324,7 @@ export { default as ${dataVariableName} } from './${idToFileName(documentId)}.js
 `
   }
 
-  const makeVariableName = flow(idToFileName, (_) => camelCase(_, { stripRegexp: /[^A-Z0-9\_]/gi }))
+  const makeVariableName = flow(idToFileName, (_) => camelCase(_, { stripRegexp: /[^A-Z0-9ㄱ-힣\_]/gi }))
 
   const docImports = documentIds
     .map((_) => `import ${makeVariableName(_)} from './${idToFileName(_)}.json'${assertStatement}`)


### PR DESCRIPTION
In the case of a Korean file name, there was an issue where Korean text was missing in the import variable names in the _index.mjs file in the .contentlayer/generated directory, so the regular expression has been fixed.