### PR TITLE
fix: handle frontmatter `body` field in mdx

### DIFF
--- a/packages/@contentlayer/source-files/src/fetchData/mapping/field-mdx.ts
+++ b/packages/@contentlayer/source-files/src/fetchData/mapping/field-mdx.ts
@@ -9,21 +9,21 @@ import { getFromDocumentContext } from '../DocumentContext.js'
 
 export const makeMdxField = ({
   mdxString,
-  fieldDef,
   options,
   contentDirPath,
+  isDocumentBodyField,
 }: {
   mdxString: string
-  fieldDef: core.FieldDef
   options: core.PluginOptions
   contentDirPath: AbsolutePosixFilePath
+  isDocumentBodyField: boolean
 }): T.Effect<HasDocumentContext & OT.HasTracer, core.UnexpectedMDXError, core.MDX> =>
   T.gen(function* ($) {
-    const isBodyField = fieldDef.name === options.fieldOptions.bodyFieldName
+    // const isDocumentBodyField = fieldDef.name === options.fieldOptions.bodyFieldName
     const rawDocumentData = yield* $(getFromDocumentContext('rawDocumentData'))
     // NOTE for the body field, we're passing the entire document file contents to MDX (e.g. in case some remark/rehype plugins need access to the frontmatter)
     // TODO we should come up with a better way to do this
-    if (isBodyField) {
+    if (isDocumentBodyField) {
       const rawContent = yield* $(getFromDocumentContext('rawContent'))
       if (rawContent.kind !== 'mdx' && rawContent.kind !== 'markdown') return utils.assertNever(rawContent)
 

--- a/packages/@contentlayer/source-files/src/fetchData/mapping/index.ts
+++ b/packages/@contentlayer/source-files/src/fetchData/mapping/index.ts
@@ -287,7 +287,8 @@ const getDataForFieldDef = ({
       }
       case 'mdx': {
         const mdxString = yield* $(parseFieldDataEff('mdx'))
-        return yield* $(makeMdxField({ mdxString, contentDirPath, fieldDef, options }))
+        const isDocumentBodyField = isRootDocument && fieldDef.name === options.fieldOptions.bodyFieldName
+        return yield* $(makeMdxField({ mdxString, contentDirPath, options, isDocumentBodyField }))
       }
       case 'image':
         const imageData = yield* $(parseFieldDataEff('image'))
@@ -402,7 +403,7 @@ const getDataForListItem = ({
       }
       case 'mdx': {
         const mdxString = yield* $(parseFieldDataEff('mdx'))
-        return yield* $(makeMdxField({ mdxString, contentDirPath, fieldDef, options }))
+        return yield* $(makeMdxField({ mdxString, contentDirPath, options, isDocumentBodyField: false }))
       }
       case 'image':
         const imageData = yield* $(parseFieldDataEff('image'))


### PR DESCRIPTION
markdown documents can have a `body` markdown field in frontmatter, which will be processed correctly, e.g.:

```ts
const Nested = defineNestedType(() => ({
  name: 'Nested',
  fields: {
    body: {
      type: 'markdown',
      required: true,
    }
  }
}))

const Post = defineDocumentType(() => ({
  name: 'Post',
  filePathPattern: `**/*.md`,
  contentType: 'markdown',
  fields: {
    title: {
      type: 'string',
      required: true,
    },
    nested: {
      type: 'nested',
      of: Nested,
      required: true
    }
  }
}))
```

however, the same fails with mdx (contentlayer will use the top-level `body` field even for `nested.body`):

```ts
const Nested = defineNestedType(() => ({
  name: 'Nested',
  fields: {
    body: {
      type: 'mdx',
      required: true,
    }
  }
}))

const Post = defineDocumentType(() => ({
  name: 'Post',
  filePathPattern: `**/*.mdx`,
  contentType: 'mdx',
  fields: {
    title: {
      type: 'string',
      required: true,
    },
    nested: {
      type: 'nested',
      of: Nested,
      required: true
    }
  }
}))
```

this is because the [markdown field](https://github.com/contentlayerdev/contentlayer/blob/main/packages/%40contentlayer/source-files/src/fetchData/mapping/field-markdown.ts#L23) checks `isRootDocument`, but the [mdx field](https://github.com/contentlayerdev/contentlayer/blob/main/packages/%40contentlayer/source-files/src/fetchData/mapping/field-mdx.ts#L22) does not. this pr makes the mdx field match the markdown field behavior.

---

for context: i ran into this because netlify-cms will create these nested frontmatter `body` fields for "single file" collections with i18n.