### PR TITLE
fix: change variable name in _index.mjs

### DIFF
--- a/packages/@contentlayer/core/src/generation/generate-dotpkg.ts
+++ b/packages/@contentlayer/core/src/generation/generate-dotpkg.ts
@@ -1,10 +1,9 @@
 import type { AbsolutePosixFilePath, RelativePosixFilePath } from '@contentlayer/utils'
 import { filePathJoin, fs, relative } from '@contentlayer/utils'
 import type { E, HasClock, HasConsole } from '@contentlayer/utils/effect'
-import { Array, Chunk, flow, OT, pipe, S, T } from '@contentlayer/utils/effect'
+import { Array, Chunk, OT, pipe, S, T } from '@contentlayer/utils/effect'
 import type { GetContentlayerVersionError } from '@contentlayer/utils/node'
 import { getContentlayerVersion } from '@contentlayer/utils/node'
-import { camelCase } from 'camel-case'
 import type { PackageJson } from 'type-fest'
 
 import { ArtifactsDir } from '../ArtifactsDir.js'
@@ -324,10 +323,8 @@ export { default as ${dataVariableName} } from './${idToFileName(documentId)}.js
 `
   }
 
-  const makeVariableName = flow(idToFileName, (_) => camelCase(_, { stripRegexp: /[^A-Z0-9ㄱ-힣\_]/gi }))
-
   const docImports = documentIds
-    .map((_) => `import ${makeVariableName(_)} from './${idToFileName(_)}.json'${assertStatement}`)
+    .map((_, index) => `import ${docDef.name + index} from './${idToFileName(_)}.json'${assertStatement}`)
     .join('\n')
 
   return `\
@@ -335,7 +332,7 @@ export { default as ${dataVariableName} } from './${idToFileName(documentId)}.js
 
 ${docImports}
 
-export const ${dataVariableName} = [${documentIds.map((_) => makeVariableName(_)).join(', ')}]
+export const ${dataVariableName} = [${documentIds.map((_, index) => docDef.name + index).join(', ')}]
 `
 }
 


### PR DESCRIPTION
Change variable name in the _index.mjs file in the .contentlayer/generated directory.

I found that this variable name caused a lot of issues. e.g. #337 #338 #385. I don't think #431 address the underlaying issue. You can't address every language problem by regular expression.

I found that the variables in the _index.mjs only work in this file. It is not used externally. So I think the variable name could be replaced by the serial number, or use something else (e.g. hash)

Like this.

![Snipaste_2023-05-31_09-15-57](https://github.com/contentlayerdev/contentlayer/assets/41602338/6e959853-bcf9-4400-88db-7bf3d9877f25)

Or this.

![image](https://github.com/contentlayerdev/contentlayer/assets/41602338/9ad441f5-c484-49de-892b-9003b978c4f7)
