### PR TITLE
Update README.md to include algolia.com/doc-beta

### DIFF
--- a/packages/contentlayer/README.md
+++ b/packages/contentlayer/README.md
@@ -110,5 +110,6 @@ Join [our Discord community](https://discord.gg/fk83HNECYJ) to get help, suggest
 - [goosebumps.fm](https://goosebumps.fm) ([Source](https://github.com/txndai/nextgoose))
 - [willin.wang](https://willin.wang) ([Source](https://github.com/willin/blog))
 - [mateusf.vercel.app](https://mateusf.vercel.app) ([Source](https://github.com/mateusfg7/mfg-b))
+- [algolia.com/doc-beta](https://www.algolia.com/doc-beta)
 
 Are you using Contentlayer? Please add your page (and repo) to the end of the list via a PR. 🙏


### PR DESCRIPTION
Adding algolia.com/doc-beta to the README list, which is currently using contentlayer + NextJS.