### PR TITLE
Bump @types dependencies to latest versions

### DIFF
--- a/examples/next-images/package.json
+++ b/examples/next-images/package.json
@@ -16,7 +16,7 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
-    "@types/react": "18.2.14",
+    "@types/react": "^18.2.21",
     "autoprefixer": "^10.4.14",
     "postcss": "^8.4.24",
     "tailwindcss": "^3.3.2",

--- a/examples/next-rsc-dynamic/package.json
+++ b/examples/next-rsc-dynamic/package.json
@@ -16,7 +16,7 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
-    "@types/react": "18.2.14",
+    "@types/react": "^18.2.21",
     "autoprefixer": "^10.4.14",
     "postcss": "^8.4.24",
     "tailwindcss": "^3.3.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@changesets/cli": "2.19.0-temp.0",
     "@effect-ts/tracing-plugin": "^0.20.0",
-    "@types/prettier": "^2.7.3",
+    "@types/prettier": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^5.60.1",
     "@typescript-eslint/parser": "^5.60.1",
     "eslint": "^8.43.0",

--- a/packages/@contentlayer/cli/package.json
+++ b/packages/@contentlayer/cli/package.json
@@ -19,7 +19,7 @@
     "typanion": "^3.12.1"
   },
   "devDependencies": {
-    "@types/node": "^20.3.2"
+    "@types/node": "^20.6.2"
   },
   "license": "MIT"
 }

--- a/packages/@contentlayer/core/package.json
+++ b/packages/@contentlayer/core/package.json
@@ -40,7 +40,7 @@
     "unified": "^10.1.2"
   },
   "devDependencies": {
-    "@types/source-map-support": "^0.5.6",
+    "@types/source-map-support": "^0.5.7",
     "markdown-wasm": "^1.2.0"
   },
   "license": "MIT"

--- a/packages/@contentlayer/source-contentful/package.json
+++ b/packages/@contentlayer/source-contentful/package.json
@@ -13,7 +13,7 @@
     "test": "echo No tests yet"
   },
   "devDependencies": {
-    "@types/node": "^20.3.2"
+    "@types/node": "^20.6.2"
   },
   "dependencies": {
     "@contentlayer/core": "workspace:*",

--- a/packages/@contentlayer/source-files/package.json
+++ b/packages/@contentlayer/source-files/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
     "@types/micromatch": "^4.0.2",
-    "@types/node": "^20.3.2",
+    "@types/node": "^20.6.2",
     "@types/sharp": "^0.32.0",
     "@types/yaml": "^1.9.7",
     "sharp": "^0.32.1",

--- a/packages/next-contentlayer/package.json
+++ b/packages/next-contentlayer/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@types/react": "^18.2.21",
-    "@types/react-dom": "^18.2.6",
+    "@types/react-dom": "^18.2.7",
     "next": "^13.4.7",
     "typescript": "^5.1.6",
     "webpack": "^5.88.1"

--- a/packages/next-contentlayer/package.json
+++ b/packages/next-contentlayer/package.json
@@ -48,7 +48,7 @@
     "react-dom": "*"
   },
   "devDependencies": {
-    "@types/react": "^18.2.14",
+    "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.6",
     "next": "^13.4.7",
     "typescript": "^5.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1805,12 +1805,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:^18.2.6":
-  version: 18.2.6
-  resolution: "@types/react-dom@npm:18.2.6"
+"@types/react-dom@npm:^18.2.7":
+  version: 18.2.7
+  resolution: "@types/react-dom@npm:18.2.7"
   dependencies:
     "@types/react": "*"
-  checksum: b56e42efab121a3a8013d2eb8c1688e6028a25ea6d33c4362d2846f0af3760b164b4d7c34846614024cfb8956cca70dd1743487f152e32ff89a00fe6fbd2be54
+  checksum: e02ea908289a7ad26053308248d2b87f6aeafd73d0e2de2a3d435947bcea0422599016ffd1c3e38ff36c42f5e1c87c7417f05b0a157e48649e4a02f21727d54f
   languageName: node
   linkType: hard
 
@@ -6919,7 +6919,7 @@ __metadata:
     "@contentlayer/core": "workspace:*"
     "@contentlayer/utils": "workspace:*"
     "@types/react": ^18.2.21
-    "@types/react-dom": ^18.2.6
+    "@types/react-dom": ^18.2.7
     next: ^13.4.7
     typescript: ^5.1.6
     webpack: ^5.88.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -1791,10 +1791,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prettier@npm:^2.7.3":
-  version: 2.7.3
-  resolution: "@types/prettier@npm:2.7.3"
-  checksum: 705384209cea6d1433ff6c187c80dcc0b95d99d5c5ce21a46a9a58060c527973506822e428789d842761e0280d25e3359300f017fbe77b9755bc772ab3dc2f83
+"@types/prettier@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@types/prettier@npm:3.0.0"
+  dependencies:
+    prettier: "*"
+  checksum: a2a512d304e5bcf78f38089dc88ad19215e6ab871d435a17aef3ce538a63b07c0e359c18db23989dc1ed9fff96d99eee1f680416080184df5c7e0e3bf767e165
   languageName: node
   linkType: hard
 
@@ -3318,7 +3320,7 @@ __metadata:
   dependencies:
     "@changesets/cli": 2.19.0-temp.0
     "@effect-ts/tracing-plugin": ^0.20.0
-    "@types/prettier": ^2.7.3
+    "@types/prettier": ^3.0.0
     "@typescript-eslint/eslint-plugin": ^5.60.1
     "@typescript-eslint/parser": ^5.60.1
     eslint: ^8.43.0
@@ -7713,6 +7715,15 @@ __metadata:
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
   checksum: cd192ec0d0a8e4c6da3bb80e4f62afe336df3f76271ac6deb0e6a36187133b6073a19e9727a1ff108cd8b9982e4768850d413baa71214dd80c7979617dca827a
+  languageName: node
+  linkType: hard
+
+"prettier@npm:*":
+  version: 3.0.3
+  resolution: "prettier@npm:3.0.3"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: e10b9af02b281f6c617362ebd2571b1d7fc9fb8a3bd17e371754428cda992e5e8d8b7a046e8f7d3e2da1dcd21aa001e2e3c797402ebb6111b5cd19609dd228e0
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1825,14 +1825,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:18.2.14, @types/react@npm:^18.2.14":
-  version: 18.2.14
-  resolution: "@types/react@npm:18.2.14"
+"@types/react@npm:^18.2.21":
+  version: 18.2.21
+  resolution: "@types/react@npm:18.2.21"
   dependencies:
     "@types/prop-types": "*"
     "@types/scheduler": "*"
     csstype: ^3.0.2
-  checksum: a6a5e8cc78f486b9020d1ad009aa6c56943c68c7c6376e0f8399e9cbcd950b7b8f5d73f00200f5379f5e58d31d57d8aed24357f301d8e86108cd438ce6c8b3dd
+  checksum: ffed203bfe7aad772b8286f7953305c9181ac3a8f27d3f5400fbbc2a8e27ca8e5bbff818ee014f39ca0d19d2b3bb154e5bdbec7e232c6f80b59069375aa78349
   languageName: node
   linkType: hard
 
@@ -6918,7 +6918,7 @@ __metadata:
   dependencies:
     "@contentlayer/core": "workspace:*"
     "@contentlayer/utils": "workspace:*"
-    "@types/react": ^18.2.14
+    "@types/react": ^18.2.21
     "@types/react-dom": ^18.2.6
     next: ^13.4.7
     typescript: ^5.1.6
@@ -6935,7 +6935,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "next-images@workspace:examples/next-images"
   dependencies:
-    "@types/react": 18.2.14
+    "@types/react": ^18.2.21
     autoprefixer: ^10.4.14
     contentlayer: latest
     date-fns: 2.30.0
@@ -6953,7 +6953,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "next-rsc-dynamic@workspace:examples/next-rsc-dynamic"
   dependencies:
-    "@types/react": 18.2.14
+    "@types/react": ^18.2.21
     autoprefixer: ^10.4.14
     contentlayer: latest
     date-fns: 2.30.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -307,7 +307,7 @@ __metadata:
   dependencies:
     "@contentlayer/core": "workspace:*"
     "@contentlayer/utils": "workspace:*"
-    "@types/node": ^20.3.2
+    "@types/node": ^20.6.2
     clipanion: ^3.2.1
     typanion: ^3.12.1
   languageName: unknown
@@ -375,7 +375,7 @@ __metadata:
   dependencies:
     "@contentlayer/core": "workspace:*"
     "@contentlayer/utils": "workspace:*"
-    "@types/node": ^20.3.2
+    "@types/node": ^20.6.2
     contentful-management: 7.22.4
   languageName: unknown
   linkType: soft
@@ -388,7 +388,7 @@ __metadata:
     "@contentlayer/utils": "workspace:*"
     "@faker-js/faker": ^8.0.2
     "@types/micromatch": ^4.0.2
-    "@types/node": ^20.3.2
+    "@types/node": ^20.6.2
     "@types/sharp": ^0.32.0
     "@types/yaml": ^1.9.7
     chokidar: ^3.5.3
@@ -1770,10 +1770,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^20.3.2":
-  version: 20.3.2
-  resolution: "@types/node@npm:20.3.2"
-  checksum: 5929ce2b9b12b1e2a2304a0921a953c72a81f5753ad39ac43b99ce6312fbb2b4fb5bc6b60d64a2550704e3223cd5de1299467d36085ac69888899db978f2653a
+"@types/node@npm:^20.6.2":
+  version: 20.6.2
+  resolution: "@types/node@npm:20.6.2"
+  checksum: 96fe5303872640a173f3fd43e289a451776ed5b8f0090094447c6790b43f23fb607eea8268af0829cef4d132e5afa0bfa4cd871aa7412e9042a414a698e9e971
   languageName: node
   linkType: hard
 
@@ -6911,24 +6911,6 @@ __metadata:
   checksum: deac9f8d00eda7b2e5cd1b2549e26e10a0faa70adaa6fdadca701cc55f49ee9018e427f424bac0c790b7c7e2d3068db97f3093f1093975f2acb8f8818b936ed9
   languageName: node
   linkType: hard
-
-"next-contentlayer-example@workspace:examples/next-contentlayer-example":
-  version: 0.0.0-use.local
-  resolution: "next-contentlayer-example@workspace:examples/next-contentlayer-example"
-  dependencies:
-    "@types/react": 18.2.14
-    autoprefixer: ^10.4.14
-    contentlayer: latest
-    date-fns: 2.30.0
-    next: 13.4.7
-    next-contentlayer: latest
-    postcss: ^8.4.24
-    react: 18.2.0
-    react-dom: 18.2.0
-    tailwindcss: ^3.3.2
-    typescript: 5.1.6
-  languageName: unknown
-  linkType: soft
 
 "next-contentlayer@workspace:*, next-contentlayer@workspace:packages/next-contentlayer":
   version: 0.0.0-use.local

--- a/yarn.lock
+++ b/yarn.lock
@@ -326,7 +326,7 @@ __metadata:
   resolution: "@contentlayer/core@workspace:packages/@contentlayer/core"
   dependencies:
     "@contentlayer/utils": "workspace:*"
-    "@types/source-map-support": ^0.5.6
+    "@types/source-map-support": ^0.5.7
     camel-case: ^4.1.2
     comment-json: ^4.2.3
     esbuild: 0.17.x || 0.18.x
@@ -1875,12 +1875,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/source-map-support@npm:^0.5.6":
-  version: 0.5.6
-  resolution: "@types/source-map-support@npm:0.5.6"
+"@types/source-map-support@npm:^0.5.7":
+  version: 0.5.7
+  resolution: "@types/source-map-support@npm:0.5.7"
   dependencies:
     source-map: ^0.6.0
-  checksum: b2b52b3e4901e52df30ebd23056885a352462c0d6fd73418e793684665a7602168e7c337241f0391562e8c1051ff37cbcb9b7d775990ee1f2a0d8a6ffa2cb22a
+  checksum: 6da844f0b8333a1789dd27ad7bb33b9bcb41159939a94451738a8f7a1e1fd69169aa6e2dda51ba8f61753c57ead159331330c996b1d672abc2e33d6991b38bf1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Bump @types/node from 20.3.2 to 20.3.6
- Bump @types/react from 18.2.14 to 18.2.21
- Bump @types/react-dom from 18.2.6 to 18.2.7
- Bump @types/prettier from 2.7.3 to 3.0.0
- Bump @types/source-map-support from 0.5.6 to 0.5.7
