### PR TITLE
Fix dynamic absolute path import for Windows fix#477

### DIFF
--- a/packages/@contentlayer/core/src/generation/generate-dotpkg.ts
+++ b/packages/@contentlayer/core/src/generation/generate-dotpkg.ts
@@ -309,33 +309,33 @@ const makePackageJson = (schemaHash: string): string => {
  */
 const writeFileWithWrittenFilesCache =
   ({ writtenFilesCache }: { writtenFilesCache: WrittenFilesCache }) =>
-    ({
-      filePath,
-      content,
-      documentHash,
-      rmBeforeWrite = true,
-    }: {
-      filePath: AbsolutePosixFilePath
-      content: string
-      documentHash?: string
-      /** In order for VSC to pick up changes in generated files, it's currently needed to delete the file before re-creating it */
-      rmBeforeWrite?: boolean
-    }) =>
-      T.gen(function* ($) {
-        // TODO also consider schema hash
-        const fileIsUpToDate = documentHash !== undefined && writtenFilesCache[filePath] === documentHash
-        if (!rmBeforeWrite && fileIsUpToDate) {
-          return
-        }
+  ({
+    filePath,
+    content,
+    documentHash,
+    rmBeforeWrite = true,
+  }: {
+    filePath: AbsolutePosixFilePath
+    content: string
+    documentHash?: string
+    /** In order for VSC to pick up changes in generated files, it's currently needed to delete the file before re-creating it */
+    rmBeforeWrite?: boolean
+  }) =>
+    T.gen(function* ($) {
+      // TODO also consider schema hash
+      const fileIsUpToDate = documentHash !== undefined && writtenFilesCache[filePath] === documentHash
+      if (!rmBeforeWrite && fileIsUpToDate) {
+        return
+      }
 
-        if (rmBeforeWrite) {
-          yield* $(fs.rm(filePath, { force: true }))
-        }
-        yield* $(fs.writeFile(filePath, content))
-        if (documentHash) {
-          writtenFilesCache[filePath] = documentHash
-        }
-      })
+      if (rmBeforeWrite) {
+        yield* $(fs.rm(filePath, { force: true }))
+      }
+      yield* $(fs.writeFile(filePath, content))
+      if (documentHash) {
+        writtenFilesCache[filePath] = documentHash
+      }
+    })
 
 const makeDataExportFile = ({
   docDef,


### PR DESCRIPTION
this PR fix issue #477 

according to https://github.com/nodejs/node/issues/31710 and https://nodejs.org/api/url.html#url_url_pathtofileurl_path
```js
import { pathToFileURL } from 'node:url';

new URL('/foo#1', 'file:');           // Incorrect: file:///foo#1
pathToFileURL('/foo#1');              // Correct:   file:///foo%231 (POSIX)

new URL('/some/path%.c', 'file:');    // Incorrect: file:///some/path%.c
pathToFileURL('/some/path%.c');       // Correct:   file:///some/path%25.c (POSIX)
```

**steps**

   0. test the fixture is right by npm patch package.
1. fork and install, follow [CONTRIBUTING.md](https://github.com/contentlayerdev/contentlayer/blob/main/CONTRIBUTING.md)
2. change `next-contentlyer-example/`[contentlayer.config.ts](https://github.com/contentlayerdev/next-contentlayer-example/blob/main/contentlayer.config.ts) add `onSuccess hook`
    ```diff
    export default makeSource({
      contentDirPath: 'posts',
      documentTypes: [Post],
    +  onSuccess: async (importData) => {
    +    const { allDocuments } = await importData()
    +    console.log('Contentlayer data successfully generated.', allDocuments.length)
    +  }
    })
    ```
3.  build `next-contentlyer-example` with no change, error occur.
    ![image](https://github.com/contentlayerdev/contentlayer/assets/72056179/18d142e7-180c-45aa-b2c5-3903bc93eda6)
4. update `packages\@contentlayer\core\src\generation\generate-dotpkg.ts`,  `yarn build` at root dir.
5. rebuild success;
6. test again on Debian linux.

win bash
![image](https://github.com/contentlayerdev/contentlayer/assets/72056179/66a34793-fbc3-4af2-8a97-4962864c5e3a)

debian
![image](https://github.com/contentlayerdev/contentlayer/assets/72056179/c21dc934-0491-4d22-853f-16f8581ca789)
