### PR TITLE
Fix exit code error in build command on Node 20+

### DIFF
--- a/.changeset/many-socks-cheat.md
+++ b/.changeset/many-socks-cheat.md
@@ -1,0 +1,16 @@
+---
+'@contentlayer/cli': patch
+---
+
+Fix exit code error in build command on **Node 20+**:
+
+```sh
+Generated 100 documents in .contentlayer
+TypeError: The "code" argument must be of type number. Received an instance of Object
+    at process.set [as exitCode] (node:internal/bootstrap/node:123:9)
+    at Cli.runExit (./node_modules/@contentlayer/cli/node_modules/clipanion/lib/advanced/Cli.js:232:26)
+    at run (file:///./node_modules/@contentlayer/cli/src/index.ts:39:3)
+    at main (./node_modules/contentlayer/bin/cli.cjs:5:3) {
+  code: 'ERR_INVALID_ARG_TYPE'
+}
+```

--- a/packages/@contentlayer/cli/src/commands/BuildCommand.ts
+++ b/packages/@contentlayer/cli/src/commands/BuildCommand.ts
@@ -25,6 +25,7 @@ export class BuildCommand extends BaseCommand {
       T.tap((config) => (config.source.options.disableImportAliasWarning ? T.unit : T.fork(core.validateTsconfig))),
       T.chain((config) => core.generateDotpkg({ config, verbose: this.verbose })),
       T.tap(core.logGenerateInfo),
+      T.map(() => 0),
       OT.withSpan('@contentlayer/cli/commands/BuildCommand:executeSafe'),
     )
 }


### PR DESCRIPTION
This should close #495 pending @schickling's take on whether this is the correct remediation. 

Although I'm very keen to dig more into **[Effect](http://effect.website/)**, I'm still very much a noob in that department. This fix assumes that since everything in the command is wrapped in an `Effect` that no additional error handling is necessary to handle _actual_ runtime errors, but I haven't tested out that assumption yet.
