### PR TITLE
Fix Changesets configuration

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,7 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["examples-*"],
+  "ignore": ["*-example", "next-rsc-dynamic", "next-images"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "useCalculatedVersionForSnapshots": true
   }


### PR DESCRIPTION
It looks like the structure of the `examples/` projects has changed since Changesets was originally configured. This removes the `example-*` glob, which is no longer necessary since all of those projects have been moved to `examples/archive` (which isn't included in `workspaces`) and updates the `ignore` glob to match the current `examples/` packages.
