### PR TITLE
Remove Florians Website from README

### DIFF
--- a/packages/contentlayer/README.md
+++ b/packages/contentlayer/README.md
@@ -117,6 +117,5 @@ Join [our Discord community](https://discord.gg/fk83HNECYJ) to get help, suggest
 - [zanreal.net](https://www.zanreal.net/)
 - [devtella](https://devtella.vercel.app/)
 - [Modern Developer Blog Template (Digital Garden Starter)](https://github.com/thedevdavid/digital-garden/)([Source](https://github.com/thedevdavid/digital-garden/))
-- [floriankiem.com](floriandwt.com) ([Source](https://github.com/floriandwt/florians-website/))
 
 Are you using Contentlayer? Please add your page (and repo) to the end of the list via a PR. 🙏


### PR DESCRIPTION
Because I'm not using NextJS anymore in this special use-case, I've used another solution for parsing my markdown. Therefore not using Contentlayer anymore (sadly) and removing my site from the Readme to keep it up to date.